### PR TITLE
Update Roblox standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 ### Added
 - Added `CFrame.fromEulerAnglesYXZ` to Roblox standard library
+- Added `ColorSequenceKeypoint` to the Roblox standard library
 
 ## [0.5.2] - 2020-01-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added `CFrame.fromEulerAnglesYXZ` to Roblox standard library
 
 ## [0.5.2] - 2020-01-19
 ### Fixed

--- a/selene/src/roblox/base.toml
+++ b/selene/src/roblox/base.toml
@@ -203,6 +203,15 @@ type = "number"
 [[CFrame.fromEulerAnglesXYZ.args]]
 type = "number"
 
+[[CFrame.fromEulerAnglesYXZ.args]]
+type = "number"
+
+[[CFrame.fromEulerAnglesYXZ.args]]
+type = "number"
+
+[[CFrame.fromEulerAnglesYXZ.args]]
+type = "number"
+
 [[CFrame.fromMatrix.args]]
 type = { display = "Vector3" }
 

--- a/selene/src/roblox/base.toml
+++ b/selene/src/roblox/base.toml
@@ -274,6 +274,12 @@ type = "any"
 type = { display = "Color3" }
 required = false
 
+[[ColorSequenceKeypoint.new.args]]
+type = "number"
+
+[[ColorSequenceKeypoint.new.args]]
+type = { display = "Color3" }
+
 [coroutine.isyieldable]
 args = []
 


### PR DESCRIPTION
Add `CFrame.fromEulerAnglesYXZ` and `ColorSequenceKeypoint` to the Roblox standard library (resolves #79 and #77).