### PR TITLE
Change how arguments passed are counted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.stderr text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Removed types from `debug.traceback` arguments in the Lua 5.1 standard library
 - Made 4th argument to `CFrame.fromMatrix` optional (#113)
+- Made standard library aware that functions and `...` can return multiple values
 
 ## [0.6.0] - 2020-04-21
 ### Added

--- a/selene-lib/src/rules/standard_library.rs
+++ b/selene-lib/src/rules/standard_library.rs
@@ -527,19 +527,19 @@ impl Visitor<'_> for StandardLibraryVisitor<'_> {
             }
         }
 
-        let mut minimum_passed_arguments = argument_types.len();
+        let mut maybe_more_arguments = false;
 
         if let ast::FunctionArgs::Parentheses { arguments, .. } = function_args {
             if let Some(ast::punctuated::Pair::End(last)) = arguments.last() {
                 if let ast::Expression::Value { value, .. } = last {
                     match &**value {
                         ast::Value::FunctionCall(_) => {
-                            minimum_passed_arguments -= 1;
+                            maybe_more_arguments = true;
                         }
                         ast::Value::Symbol(token_ref) => {
                             if let TokenType::Symbol { symbol } = token_ref.token().token_type() {
                                 if symbol == &full_moon::tokenizer::Symbol::Ellipse {
-                                    minimum_passed_arguments -= 1;
+                                    maybe_more_arguments = true;
                                 }
                             }
                         }
@@ -551,8 +551,8 @@ impl Visitor<'_> for StandardLibraryVisitor<'_> {
 
         let arguments_length = argument_types.len();
 
-        if (minimum_passed_arguments == arguments_length && arguments_length < expected_args)
-            || (!vararg && minimum_passed_arguments > max_args)
+        if (arguments_length < expected_args && !maybe_more_arguments)
+            || (!vararg && arguments_length > max_args)
         {
             self.diagnostics.push(Diagnostic::new(
                 "incorrect_standard_library_use",

--- a/selene-lib/src/rules/standard_library.rs
+++ b/selene-lib/src/rules/standard_library.rs
@@ -527,12 +527,32 @@ impl Visitor<'_> for StandardLibraryVisitor<'_> {
             }
         }
 
-        let any_are_vararg = argument_types.iter().any(|(_, argument_type)| {
-            argument_type.as_ref() == Some(&PassedArgumentType::Primitive(ArgumentType::Vararg))
-        });
+        let mut minimum_passed_arguments = argument_types.len();
 
-        if (!any_are_vararg && argument_types.len() < expected_args)
-            || (!vararg && argument_types.len() > max_args)
+        if let ast::FunctionArgs::Parentheses { arguments, .. } = function_args {
+            if let Some(ast::punctuated::Pair::End(last)) = arguments.last() {
+                if let ast::Expression::Value { value, .. } = last {
+                    match &**value {
+                        ast::Value::FunctionCall(_) => {
+                            minimum_passed_arguments -= 1;
+                        }
+                        ast::Value::Symbol(token_ref) => {
+                            if let TokenType::Symbol { symbol } = token_ref.token().token_type() {
+                                if symbol == &full_moon::tokenizer::Symbol::Ellipse {
+                                    minimum_passed_arguments -= 1;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        };
+
+        let arguments_length = argument_types.len();
+
+        if (minimum_passed_arguments == arguments_length && arguments_length < expected_args)
+            || (!vararg && minimum_passed_arguments > max_args)
         {
             self.diagnostics.push(Diagnostic::new(
                 "incorrect_standard_library_use",
@@ -665,6 +685,15 @@ mod tests {
             StandardLibraryLint::new(()).unwrap(),
             "standard_library",
             "any",
+        );
+    }
+
+    #[test]
+    fn test_assert() {
+        test_lint(
+            StandardLibraryLint::new(()).unwrap(),
+            "standard_library",
+            "assert",
         );
     }
 

--- a/selene-lib/tests/lints/standard_library/assert.lua
+++ b/selene-lib/tests/lints/standard_library/assert.lua
@@ -1,0 +1,4 @@
+assert(true, 'message')
+assert(call())
+assert(true)
+assert(call(), 'this is ok')

--- a/selene-lib/tests/lints/standard_library/assert.lua
+++ b/selene-lib/tests/lints/standard_library/assert.lua
@@ -1,4 +1,8 @@
 assert(true, "message")
 assert(call())
-assert(true)
 assert(call(), "this is ok")
+assert(...)
+
+assert(true)
+assert(true, "message", call())
+assert(true, "message", ...)

--- a/selene-lib/tests/lints/standard_library/assert.lua
+++ b/selene-lib/tests/lints/standard_library/assert.lua
@@ -1,4 +1,4 @@
-assert(true, 'message')
+assert(true, "message")
 assert(call())
 assert(true)
-assert(call(), 'this is ok')
+assert(call(), "this is ok")

--- a/selene-lib/tests/lints/standard_library/assert.std.toml
+++ b/selene-lib/tests/lints/standard_library/assert.std.toml
@@ -1,0 +1,6 @@
+[[assert.args]]
+type = "any"
+
+[[assert.args]]
+type = "string"
+required = "A failed assertion without a message is unhelpful to users."

--- a/selene-lib/tests/lints/standard_library/assert.stderr
+++ b/selene-lib/tests/lints/standard_library/assert.stderr
@@ -1,8 +1,24 @@
 error[incorrect_standard_library_use]: standard library function `assert` requires 2 parameters, 1 passed
 
-   ┌── assert.lua:3:1 ───
+   ┌── assert.lua:6:1 ───
    │
- 3 │ assert(true)
+ 6 │ assert(true)
    │ ^^^^^^^^^^^^
+   │
+
+error[incorrect_standard_library_use]: standard library function `assert` requires 2 parameters, 3 passed
+
+   ┌── assert.lua:7:1 ───
+   │
+ 7 │ assert(true, "message", call())
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+
+error[incorrect_standard_library_use]: standard library function `assert` requires 2 parameters, 3 passed
+
+   ┌── assert.lua:8:1 ───
+   │
+ 8 │ assert(true, "message", ...)
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
 

--- a/selene-lib/tests/lints/standard_library/assert.stderr
+++ b/selene-lib/tests/lints/standard_library/assert.stderr
@@ -1,0 +1,8 @@
+error[incorrect_standard_library_use]: standard library function `assert` requires 2 parameters, 1 passed
+
+   ┌── assert.lua:3:1 ───
+   │
+ 3 │ assert(true)
+   │ ^^^^^^^^^^^^
+   │
+


### PR DESCRIPTION
Closes #103 

I added a .gitattributes so that on checkout, git does not change line endings for the `.stderr` files. Otherwise it makes all the lint tests fail if someone has `core.autocrlf` on. I'm not that familiar with that kind of stuff but from the test I made I think it works.

This is an attempt at fixing this use case:
```lua
assert(t.string(variable))
```
The standard library enforces that `assert` is called with two arguments, which I think is a good idea. But it does not work well when using a library like [`t`](https://github.com/Roblox/t), that uses function that returns the two values.

#### What I did
The way I solved it is by checking if the last value passed to the function is a `...` or a function call. Then if it is, it updates the minimum amount of values passed to the function. So it is still possible to know if there are too much arguments.

#### Another option
Another way I thought about doing it was to change the `get_argument_type` function to return `ArgumentType::Vararg` in the function call case. After that it's possible to just check if the last argument type is `Vararg` to determine if the max number of arguments is unknown or not.

I don't know if that could have a larger impact on other stuff so that's why I went with what I did.

#### Bad side of the fix
The sad thing is that it allows weird things to pass. Like this for example:
```
print( type(print(), print()) )
```
Which is technically correct, but horrible.

Let me know your thoughts!