### PR TITLE
Remove lint when use unbalanced assignment with ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - setmetatable no longer requires a second argument.
 - `allow_unused_self` is now toggled on for `unused_variable` by default.
-- unbalanced assignments with ellipsis no longer lints
 
 ### Fixed
 - Using a function call as the last argument in a function will silence lint for not passing enough parameters. This means, for example, `math.max(unpack(numbers))` will no longer error.
+- Using an ellipsis on the right side of unbalanced assignments no longer lints.
 
 ## [0.8.0] - 2020-08-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - setmetatable no longer requires a second argument.
 - `allow_unused_self` is now toggled on for `unused_variable` by default.
+- unbalanced assignments with ellipsis no longer lints
 
 ### Fixed
 - Using a function call as the last argument in a function will silence lint for not passing enough parameters. This means, for example, `math.max(unpack(numbers))` will no longer error.

--- a/selene-lib/src/rules/unbalanced_assignments.rs
+++ b/selene-lib/src/rules/unbalanced_assignments.rs
@@ -114,18 +114,13 @@ fn expression_is_nil(expression: &ast::Expression) -> bool {
 }
 
 fn expression_is_ellipsis(expression: &ast::Expression) -> bool {
-    match expression {
-        ast::Expression::Value{value, ..} => {
-            if let ast::Value::Symbol(symbol) = &**value {
-                *symbol.token_type() == TokenType::Symbol { symbol: Symbol::Ellipse} 
-            } else {
-                false
-            }
-            
-        },
-
-        _ => false
+    if let ast::Expression::Value{value, ..} = expression {
+        if let ast::Value::Symbol(symbol) = &**value {
+            return *symbol.token_type() == TokenType::Symbol { symbol: Symbol::Ellipse };
+        }
     }
+
+    false
 }
 
 fn range<'a, N: Node<'a>>(node: N) -> (u32, u32) {

--- a/selene-lib/src/rules/unbalanced_assignments.rs
+++ b/selene-lib/src/rules/unbalanced_assignments.rs
@@ -113,6 +113,21 @@ fn expression_is_nil(expression: &ast::Expression) -> bool {
     }
 }
 
+fn expression_is_ellipsis(expression: &ast::Expression) -> bool {
+    match expression {
+        ast::Expression::Value{value, ..} => {
+            if let ast::Value::Symbol(symbol) = &**value {
+                *symbol.token_type() == TokenType::Symbol { symbol: Symbol::Ellipse} 
+            } else {
+                false
+            }
+            
+        },
+
+        _ => false
+    }
+}
+
 fn range<'a, N: Node<'a>>(node: N) -> (u32, u32) {
     let (start, end) = node.range().unwrap();
     (start.bytes() as u32, end.bytes() as u32)
@@ -142,7 +157,7 @@ impl UnbalancedAssignmentsVisitor {
                 ),
                 ..UnbalancedAssignment::default()
             });
-        } else if rhs.len() < lhs && !expression_is_call(last_rhs) && !expression_is_nil(last_rhs) {
+        } else if rhs.len() < lhs && !expression_is_ellipsis(last_rhs) && !expression_is_call(last_rhs) && !expression_is_nil(last_rhs) {
             self.assignments.push(UnbalancedAssignment {
                 first_call: rhs.iter().find(|e| expression_is_call(e)).map(range),
                 range: range(rhs),

--- a/selene-lib/tests/lints/unbalanced_assignments/unbalanced_assignments.lua
+++ b/selene-lib/tests/lints/unbalanced_assignments/unbalanced_assignments.lua
@@ -12,3 +12,5 @@ a, b, c = nil
 
 local a, b, c = 1, 2, 3, 4
 x = 1, 2
+
+local a, b, c = ...


### PR DESCRIPTION
Remove lint when using unbalanced assignments with ellipsis, e.g. ```local a, b, c = ...```

resolves https://github.com/Kampfkarren/selene/issues/99