### PR TITLE
Roblox Lua allows error first argument to be a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Added inline lint filtering, read [the documentation](https://kampfkarren.github.io/selene/usage/filtering.html) for more information.
 - More errors now set the exit code.
+- Added support for error({any}) to the Roblox standard library.
 
 ## [0.9.2] - 2020-11-06
 ### Changed

--- a/selene/src/roblox/base.toml
+++ b/selene/src/roblox/base.toml
@@ -342,6 +342,14 @@ required = false
 [elapsedTime]
 args=[]
 
+[[error.args]]
+type = "any"
+required = "Erroring without an explanation is unhelpful to users."
+
+[[error.args]]
+type = "number"
+required = false
+
 [[Faces.new.args]]
 type = "..."
 


### PR DESCRIPTION
* Add an entry to the Roblox config that allows more than strings for the first argument to error()

Closes #180 