### PR TITLE
Fix minor spelling and formatting in docs

### DIFF
--- a/docs/src/lints/roblox_incorrect_roact_usage.md
+++ b/docs/src/lints/roblox_incorrect_roact_usage.md
@@ -15,7 +15,7 @@ Roact.createElement("BadClass", {})
 ```
 
 ## Remarks
-This lint is naiive and makes several assumptions about the way you write your code. The assumptions are based on idiomatic Roact.
+This lint is naive and makes several assumptions about the way you write your code. The assumptions are based on idiomatic Roact.
 
 1. It assumes you are either calling `Roact.createElement` directly or creating a local variable that's assigned to `Roact.createElement`.
 2. It assumes if you are using a local variable, you're not reassigning it.

--- a/docs/src/lints/type_check_inside_call.md
+++ b/docs/src/lints/type_check_inside_call.md
@@ -3,7 +3,7 @@
 Checks for `type(foo == "type")`, instead of `type(foo) == "type"`.
 
 ## Why this is bad
-This will always return `"boolean"`, and is undoubtably not what you intended to write.
+This will always return `"boolean"`, and is undoubtedly not what you intended to write.
 
 ## Example
 ```lua

--- a/docs/src/lints/unscoped_variables.md
+++ b/docs/src/lints/unscoped_variables.md
@@ -1,4 +1,4 @@
-# unused_variable
+# unscoped_variables
 ## What it does
 Checks for variables that are unscoped (don't have a local variable attached).
 

--- a/docs/src/luacheck.md
+++ b/docs/src/luacheck.md
@@ -4,7 +4,7 @@
 selene is not the first Lua linter. The main inspiration behind selene is [luacheck](https://luacheck.readthedocs.io/en/stable/). However, the two have very little in common besides inception.
 
 - selene is actively maintained, while at the time of writing luacheck's last commit was in October 2018.
-- selene is written in Rust, while luacheck is written in Lua. In practice, this means that selene is much faster than luacheck while also being able to easily take advantage of features luacheck cannot because of the difficulty of using depenedencies in Lua.
+- selene is written in Rust, while luacheck is written in Lua. In practice, this means that selene is much faster than luacheck while also being able to easily take advantage of features luacheck cannot because of the difficulty of using dependencies in Lua.
 - selene is multithreaded, again leading to significantly better performance.
 - selene has rich output, while luacheck has basic output.
 

--- a/docs/src/motivation.md
+++ b/docs/src/motivation.md
@@ -1,6 +1,6 @@
 # Motivation
 
-### Because bugs
+## Because bugs
 When writing any code, it's very easy to make silly mistakes that end up introducing bugs. A lot of the time, these bugs are hard to track down and debug, and sometimes are even harder to replicate.
 
 This risk is made ever more real because of the generally lax nature of Lua. Incorrect code is regularly passed off and isn't noticed until something breaks at runtime. Sometimes you'll get a clear error message, and will have to spend time going back, fixing the code, and making sure you actually fixed it. Other times, the effects are more hidden, and instead of getting an error your code will just pass through along, in an incorrect state.

--- a/docs/src/selene.md
+++ b/docs/src/selene.md
@@ -7,6 +7,6 @@
 - **Interested in contributing to selene's codebase?** Read the [contribution guide](./contributing.md).
 - **Want to discuss selene or get help?** Join the [Roblox OS Community Discord](https://discord.gg/mhtGUS8). Note: selene is not Roblox exclusive, but it started its life for Roblox development.
 
-### License
+## License
 
 selene and all its source code are licensed under the [Mozilla Public License 2.0](https://www.mozilla.org/MPL/2.0/).

--- a/docs/src/usage/std.md
+++ b/docs/src/usage/std.md
@@ -1,7 +1,7 @@
 # Standard Library Format
 selene provides a robust standard library format to allow for use with environments other than vanilla Lua. Standard libraries are defined in the form of [TOML](https://github.com/toml-lang/toml) files.
 
-# Examples
+## Examples
 For examples of the standard library format, see:
 - [`lua51.toml`](https://github.com/Kampfkarren/selene/blob/master/selene-lib/default_std/lua51.toml) - The default standard library for Lua 5.1
 - [`lua52.toml`](https://github.com/Kampfkarren/selene/blob/master/selene-lib/default_std/lua52.toml) - A standard library for Lua 5.2's additions and removals. Reference this if your standard library is based off another (it most likely is).
@@ -128,7 +128,7 @@ removed = true
 
 Used when your standard library is based off another, and your library removes something from the original.
 
-# Structs
+## Structs
 
 Structs are used in places such as Roblox Instances. Every Instance in Roblox, for example, declares a `:GetChildren()` method. We don't want to have to define this everywhere an Instance is declared globally, so instead we just define it once in a struct.
 
@@ -151,7 +151,7 @@ struct = "Event"
 
 ...and selene will know that `workspace.Changed:Connect(callback)` is valid, but `workspace.Changed:RandomNameHere()` is not.
 
-# Wildcards
+## Wildcards
 Fields can specify requirements if a field is referenced that is not explicitly named. For example, in Roblox, instances can have arbitrary fields of other instances (`workspace.Baseplate` indexes an instance named Baseplate inside `workspace`, but `Baseplate` is nowhere in the Roblox API).
 
 We can specify this behavior by using the special `"*"` field.


### PR DESCRIPTION
Nothing super helpful here, but hopefully little bit of cleanup.  Just typos in the docs and formatting on markdown header indentation levels.

Only other spelling tidbit is `parenthese` which should be `parenthesis` if singular or `parentheses` if plural, but probably not worth changing since it's part of the external lint config rules