### PR TITLE
Fix diagnostic positions when using Unicode characters

### DIFF
--- a/selene-vscode/CHANGELOG.md
+++ b/selene-vscode/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "selene-vscode" extension will be documented in this 
 
 If you want to stay up to date with selene itself, you can find the changelog in [selene's CHANGELOG.md](https://github.com/Kampfkarren/selene/blob/master/CHANGELOG.md).
 
+## [Unreleased]
+-   Fixed incorrect diagnostics positions when using Unicode characters
+
 ## [1.0.2]
 -   Fixed a bug where diagnostics would not be removed when a file was deleted.
 

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -26,10 +26,24 @@ enum Severity {
     Warning = "Warning",
 }
 
+function byteToCharOffset(document: vscode.TextDocument, byteOffset: number) {
+    const text = document.getText();
+    let currentOffset = 0;
+    // Iterate through each character in the string
+    for (let i = 0; i < byteOffset; i++) {
+        // Calculate the current byte offset we have reached so far
+        currentOffset += Buffer.byteLength(text[i], "utf-8");
+        if (currentOffset >= byteOffset) {
+            return i + 1
+        }
+    }
+    return currentOffset
+}
+
 function labelToRange(document: vscode.TextDocument, label: Label): vscode.Range {
     return new vscode.Range(
-        document.positionAt(label.span.start),
-        document.positionAt(label.span.end),
+        document.positionAt(byteToCharOffset(document, label.span.start)),
+        document.positionAt(byteToCharOffset(document, label.span.end)),
     )
 }
 

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -27,25 +27,27 @@ enum Severity {
 }
 
 function byteToCharMap(document: vscode.TextDocument, byteOffsets: Set<number>) {
-    const text = document.getText();
-    const byteOffsetMap = new Map<number, number>();
-    let currentOffset = 0;
+    const text = document.getText()
+    const byteOffsetMap = new Map<number, number>()
+    let currentOffset = 0
 
     // Iterate through each character in the string 
-    for (let i = 0; i < text.length; i++) {
+    for (let charOffset = 0; charOffset < text.length; charOffset++) {
         // Calculate the current byte offset we have reached so far
-        currentOffset += Buffer.byteLength(text[i], "utf-8");
+        currentOffset += Buffer.byteLength(text[charOffset], "utf-8")
         for (const offset of byteOffsets) {
             if (currentOffset >= offset) {
-                byteOffsetMap.set(offset, i + 1)
+                byteOffsetMap.set(offset, charOffset + 1)
                 byteOffsets.delete(offset)
 
-                if (byteOffsets.size === 0) break
+                if (byteOffsets.size === 0) {
+                    return byteOffsetMap
+                }
             }
         }
     }
 
-    return byteOffsetMap;
+    return byteOffsetMap
 }
 
 function labelToRange(document: vscode.TextDocument, label: Label, byteOffsetMap: Map<number, number>): vscode.Range {


### PR DESCRIPTION
This PR should fix the problem where diagnostics were incorrectly positioned in the VSCode extension when there are Unicode characters in the file

VSCode only accepts character offsets, however selene will return byte offsets for its start and end positions. This PR implements a conversion from byte offsets to character positions