### PR TITLE
Use `vscode.workspace.fs` where possible

### DIFF
--- a/selene-vscode/CHANGELOG.md
+++ b/selene-vscode/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "selene-vscode" extension will be documented in this 
 
 If you want to stay up to date with selene itself, you can find the changelog in [selene's CHANGELOG.md](https://github.com/Kampfkarren/selene/blob/master/CHANGELOG.md).
 
+## [Unreleased]
+-   Updated the internal `fs` code to use VSCode FileSystem rather than Node.js fs methods.
+
 ## [1.0.3]
 -   Fixed incorrect diagnostics positions when using Unicode characters
 

--- a/selene-vscode/package-lock.json
+++ b/selene-vscode/package-lock.json
@@ -102,9 +102,9 @@
 			}
 		},
 		"@types/vscode": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-			"integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
+			"integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
 			"dev": true
 		},
 		"agent-base": {

--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -6,7 +6,7 @@
     "publisher": "Kampfkarren",
     "repository": "https://github.com/Kampfkarren/selene",
     "engines": {
-        "vscode": "^1.44.0"
+        "vscode": "^1.54.0"
     },
     "categories": [
         "Linters"
@@ -52,7 +52,7 @@
         "@types/request": "^2.48.4",
         "@types/request-promise-native": "^1.0.17",
         "@types/unzipper": "^0.10.3",
-        "@types/vscode": "^1.44.0",
+        "@types/vscode": "^1.54.0",
         "glob": "^7.1.5",
         "mocha": "^6.2.3",
         "tslint": "^5.20.0",

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -92,9 +92,7 @@ export async function activate(context: vscode.ExtensionContext) {
             context.globalStorageUri,
             "--display-style=json -",
             selene.Expectation.Stderr,
-            vscode.workspace.getWorkspaceFolder(
-                vscode.Uri.file(document.uri.fsPath),
-            )?.uri?.fsPath,
+            vscode.workspace.getWorkspaceFolder(document.uri),
             document.getText(),
         )
 

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -31,7 +31,7 @@ function byteToCharMap(document: vscode.TextDocument, byteOffsets: Set<number>) 
     const byteOffsetMap = new Map<number, number>()
     let currentOffset = 0
 
-    // Iterate through each character in the string 
+    // Iterate through each character in the string
     for (let charOffset = 0; charOffset < text.length; charOffset++) {
         // Calculate the current byte offset we have reached so far
         currentOffset += Buffer.byteLength(text[charOffset], "utf-8")
@@ -60,7 +60,7 @@ function labelToRange(document: vscode.TextDocument, label: Label, byteOffsetMap
 export async function activate(context: vscode.ExtensionContext) {
     console.log("selene-vscode activated")
 
-    trySelene = util.ensureSeleneExists(context.globalStoragePath).then(() => {
+    trySelene = util.ensureSeleneExists(context.globalStorageUri).then(() => {
         return true
     }).catch(error => {
         vscode.window.showErrorMessage(`An error occurred when finding Selene:\n${error}`)
@@ -69,10 +69,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
     await trySelene
 
-    console.log("selene path", await util.getSelenePath(context.globalStoragePath))
+    console.log("selene path", await util.getSelenePath(context.globalStorageUri))
 
     context.subscriptions.push(vscode.commands.registerCommand("selene.reinstall", () => {
-        trySelene = util.downloadSelene(context.globalStoragePath).then(() => true).catch(() => false)
+        trySelene = util.downloadSelene(context.globalStorageUri).then(() => true).catch(() => false)
         return trySelene
     }))
 
@@ -89,7 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         const output = await selene.seleneCommand(
-            context.globalStoragePath,
+            context.globalStorageUri,
             "--display-style=json -",
             selene.Expectation.Stderr,
             vscode.workspace.getWorkspaceFolder(

--- a/selene-vscode/src/selene.ts
+++ b/selene-vscode/src/selene.ts
@@ -9,7 +9,7 @@ export enum Expectation {
 }
 
 export async function seleneCommand(
-    storagePath: string,
+    storagePath: vscode.Uri,
     command: string,
     expectation: Expectation,
     cwd?: string,

--- a/selene-vscode/src/selene.ts
+++ b/selene-vscode/src/selene.ts
@@ -12,18 +12,17 @@ export async function seleneCommand(
     storagePath: vscode.Uri,
     command: string,
     expectation: Expectation,
-    cwd?: string,
+    workspace?: vscode.WorkspaceFolder,
     stdin?: string,
 ): Promise<string | null> {
     return new Promise(async (resolve, reject) => {
-        const child = childProcess.exec(`"${await util.getSelenePath(storagePath).then(path => {
-            if (path === undefined) {
-                return Promise.reject("Could not find selene.")
-            }
+        const selenePath = await util.getSelenePath(storagePath)
+        if (selenePath === undefined) {
+            return reject("Could not find selene.")
+        }
 
-            return path
-        })}" ${command}`, {
-            cwd,
+        const child = childProcess.exec(`"${selenePath.fsPath}" ${command}`, {
+            cwd: workspace?.uri.fsPath,
         }, (error, stdout) => {
             if (expectation === Expectation.Stderr) {
                 resolve(error && stdout)

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -84,11 +84,11 @@ function getSeleneFilenamePattern(): RegExp {
 
 async function fileExists(filename: vscode.Uri): Promise<boolean> {
     try {
-        await vscode.workspace.fs.stat(filename);
-        return true;
+        await vscode.workspace.fs.stat(filename)
+        return true
     } catch (err) {
         // If an error was thrown, the file was not found
-        return false;
+        return false
     }
 }
 
@@ -133,7 +133,7 @@ export async function getSelenePath(storagePath: vscode.Uri): Promise<vscode.Uri
         return vscode.Uri.file(settingPath)
     }
 
-    const downloadPath = vscode.Uri.joinPath(storagePath, getSeleneFilename());
+    const downloadPath = vscode.Uri.joinPath(storagePath, getSeleneFilename())
     if (await fileExists(downloadPath)) {
         return downloadPath
     }

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -87,8 +87,7 @@ async function fileExists(filename: vscode.Uri): Promise<boolean> {
         await vscode.workspace.fs.stat(filename)
         return true
     } catch (err) {
-        // If an error was thrown, the file was not found
-        return false
+        return err != vscode.FileSystemError.FileNotFound
     }
 }
 

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -143,7 +143,7 @@ export async function ensureSeleneExists(storagePath: vscode.Uri) {
     const path = await getSelenePath(storagePath)
 
     if (path === undefined) {
-        await vscode.workspace.fs.createDirectory(storagePath);
+        await vscode.workspace.fs.createDirectory(storagePath)
         return downloadSelene(storagePath)
     } else {
         if (!await fileExists(path)) {

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -1,6 +1,4 @@
-import * as fs from "fs"
 import * as os from "os"
-import * as path from "path"
 import * as selene from "./selene"
 import * as requestNative from "request"
 import * as request from "request-promise-native"
@@ -84,13 +82,19 @@ function getSeleneFilenamePattern(): RegExp {
     }
 }
 
-async function fileExists(filename: string): Promise<boolean> {
-    return fs.promises.stat(filename)
-        .then(() => true)
-        .catch((error) => error.code !== "ENOENT")
+async function fileExists(filename: vscode.Uri): Promise<boolean> {
+    try {
+        await vscode.workspace.fs.stat(filename);
+    } catch (err) {
+        if (err == vscode.FileSystemError.FileNotFound) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
-export async function downloadSelene(directory: string) {
+export async function downloadSelene(directory: vscode.Uri) {
     vscode.window.showInformationMessage("Downloading Selene...")
 
     const filename = getSeleneFilename()
@@ -99,7 +103,7 @@ export async function downloadSelene(directory: string) {
 
     for (const asset of release.assets) {
         if (filenamePattern.test(asset.name)) {
-            const file = fsWriteFileAtomic(path.join(directory, filename), {
+            const file = fsWriteFileAtomic(vscode.Uri.joinPath(directory, filename).fsPath, {
                 mode: 0o755,
             })
 
@@ -125,23 +129,23 @@ export async function downloadSelene(directory: string) {
     }
 }
 
-export async function getSelenePath(storagePath: string): Promise<string | undefined> {
+export async function getSelenePath(storagePath: vscode.Uri): Promise<vscode.Uri | undefined> {
     const settingPath = vscode.workspace.getConfiguration("selene").get<string | null>("selenePath")
     if (settingPath) {
-        return settingPath
+        return vscode.Uri.file(settingPath)
     }
 
-    const downloadPath = path.join(storagePath, getSeleneFilename())
+    const downloadPath = vscode.Uri.joinPath(storagePath, getSeleneFilename());
     if (await fileExists(downloadPath)) {
         return downloadPath
     }
 }
 
-export async function ensureSeleneExists(storagePath: string) {
+export async function ensureSeleneExists(storagePath: vscode.Uri) {
     const path = await getSelenePath(storagePath)
 
     if (path === undefined) {
-        await fs.promises.mkdir(storagePath, { recursive: true })
+        vscode.workspace.fs.createDirectory(storagePath);
         return downloadSelene(storagePath)
     } else {
         if (!await fileExists(path)) {
@@ -156,7 +160,7 @@ export async function ensureSeleneExists(storagePath: string) {
     }
 }
 
-function openUpdatePrompt(directory: string, release: GithubRelease) {
+function openUpdatePrompt(directory: vscode.Uri, release: GithubRelease) {
     vscode.window.showInformationMessage(
         `There's an update available for selene: ${release.tag_name}`,
         "Install Update",

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -87,7 +87,7 @@ async function fileExists(filename: vscode.Uri): Promise<boolean> {
         await vscode.workspace.fs.stat(filename)
         return true
     } catch (err) {
-        return err != vscode.FileSystemError.FileNotFound
+        return err !== vscode.FileSystemError.FileNotFound
     }
 }
 

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -143,7 +143,7 @@ export async function ensureSeleneExists(storagePath: vscode.Uri) {
     const path = await getSelenePath(storagePath)
 
     if (path === undefined) {
-        vscode.workspace.fs.createDirectory(storagePath);
+        await vscode.workspace.fs.createDirectory(storagePath);
         return downloadSelene(storagePath)
     } else {
         if (!await fileExists(path)) {

--- a/selene-vscode/src/util.ts
+++ b/selene-vscode/src/util.ts
@@ -85,13 +85,11 @@ function getSeleneFilenamePattern(): RegExp {
 async function fileExists(filename: vscode.Uri): Promise<boolean> {
     try {
         await vscode.workspace.fs.stat(filename);
+        return true;
     } catch (err) {
-        if (err == vscode.FileSystemError.FileNotFound) {
-            return false;
-        }
+        // If an error was thrown, the file was not found
+        return false;
     }
-
-    return true;
 }
 
 export async function downloadSelene(directory: vscode.Uri) {


### PR DESCRIPTION
This PR makes uses of `vscode.workspace.fs` instead of the Node.js `fs` and `path` module, where possible.
I had to bump the VSCode engine version to latest, to use some newer `fs`-related methods.

We now pass around `vscode.Uri`s where possible, instead of file system paths (however we *do* still need them).
Using this allows us to handle remote/other file uris.

One thing that wasn't changed, was using `fsWriteFileAtomic` to download the extension. `vscode.workspace.fs.writeFile` is an alternative, but I'm not sure if its suited for writing such a large binary, and it doesn't support piping the stream.