### PR TITLE
Show more diagnostic information in extension when available

### DIFF
--- a/selene-vscode/CHANGELOG.md
+++ b/selene-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@ If you want to stay up to date with selene itself, you can find the changelog in
 
 ## [Unreleased]
 -   Updated the internal `fs` code to use VSCode FileSystem rather than Node.js fs methods.
+-   Fixed some information (mainly parse error information) missing from diagnostics which were available in the selene CLI
 
 ## [1.0.3]
 -   Fixed incorrect diagnostics positions when using Unicode characters

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -124,6 +124,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
         for (const data of dataToAdd) {
             let message = data.message
+            if (data.primary_label.message.length > 0) {
+                message += `, ${data.primary_label.message}`
+            }
+
             if (data.notes.length > 0) {
                 message += `\n${data.notes.map(note => `note: ${note}\n`)}`
             }


### PR DESCRIPTION
Selene provides extra diagnostic information in some cases (mainly parse errors). This information, however, is not currently shown in the extension.
For example:
```lua
function() end
```
What is shown: `unexpected token '('`
Extra information available, but not shown: `expected function name`.
This updates the message to show `unexpected token '(', expected function name`.

This can help in understanding the diagnostic messages better, as it provides useful contextual information.