### PR TITLE
Added `onSave` and `onType` extension configuration

### DIFF
--- a/selene-vscode/CHANGELOG.md
+++ b/selene-vscode/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to the "selene-vscode" extension will be documented in this 
 If you want to stay up to date with selene itself, you can find the changelog in [selene's CHANGELOG.md](https://github.com/Kampfkarren/selene/blob/master/CHANGELOG.md).
 
 ## [Unreleased]
+-   Add `onSave` and `onType` configuration to choose when selene lints.
 -   Updated the internal `fs` code to use VSCode FileSystem rather than Node.js fs methods.
--   Fixed some information (mainly parse error information) missing from diagnostics which were available in the selene CLI
+-   Fixed some information (mainly parse error information) missing from diagnostics which were available in the selene CLI.
 
 ## [1.0.3]
 -   Fixed incorrect diagnostics positions when using Unicode characters

--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -40,13 +40,13 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Specifies the path of selene. If not specified, selene will be automatically downloaded from the GitHub releases."
+                    "description": "Specifies the path of selene. If not specified, selene will automatically download from the GitHub releases."
                 },
                 "selene.run": {
                     "type": "string",
                     "default": "onType",
                     "enum": ["onSave", "onType"],
-                    "description": "Run the linter `onSave` or `onType`."
+                    "description": "Run the linter as you type (onType) or when the file is saved (onSave)."
                 }
             }
         }

--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -40,7 +40,7 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Specifies the path of selene. If not specified, selene will be automatically download from the GitHub releases."
+                    "description": "Specifies the path of selene. If not specified, selene will be automatically downloaded from the GitHub releases."
                 },
                 "selene.run": {
                     "type": "string",

--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -40,7 +40,13 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "Specifies the path of selene. If not specified, will automatically download one from the GitHub releases."
+                    "description": "Specifies the path of selene. If not specified, selene will be automatically download from the GitHub releases."
+                },
+                "selene.run": {
+                    "type": "string",
+                    "default": "onType",
+                    "enum": ["onSave", "onType"],
+                    "description": "Run the linter `onSave` or `onType`."
                 }
             }
         }

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -166,14 +166,13 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     function listenToChange() {
-		switch (vscode.workspace.getConfiguration("selene").get<RunType>("run")) {
-            case RunType.OnSave: {
+        switch (vscode.workspace.getConfiguration("selene").get<RunType>("run")) {
+            case RunType.OnSave:
                 return vscode.workspace.onDidSaveTextDocument(lint)
-            }
-            case RunType.OnType: {
+            case RunType.OnType:
                 return vscode.workspace.onDidChangeTextDocument(event => lint(event.document))
-            }
-		}
+
+        }
     }
 
     let disposable = listenToChange()

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -26,6 +26,11 @@ enum Severity {
     Warning = "Warning",
 }
 
+enum RunType {
+    OnSave = "onSave",
+    OnType = "onType",
+}
+
 function byteToCharMap(document: vscode.TextDocument, byteOffsets: Set<number>) {
     const text = document.getText()
     const byteOffsetMap = new Map<number, number>()
@@ -161,11 +166,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     function listenToChange() {
-		switch (vscode.workspace.getConfiguration("selene").get<string>("run")) {
-            case "onSave": {
+		switch (vscode.workspace.getConfiguration("selene").get<RunType>("run")) {
+            case RunType.OnSave: {
                 return vscode.workspace.onDidSaveTextDocument(lint)
             }
-            case "onType": {
+            case RunType.OnType: {
                 return vscode.workspace.onDidChangeTextDocument(event => lint(event.document))
             }
 		}

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -160,24 +160,22 @@ export async function activate(context: vscode.ExtensionContext) {
         diagnosticsCollection.set(document.uri, diagnostics)
     }
 
-    let disposable: vscode.Disposable
     function listenToChange() {
-        if (disposable) {
-            disposable.dispose()
-        }
-
-        const lintOn = vscode.workspace.getConfiguration("selene").get<string>("run")
-        if (lintOn === "onSave") {
-            disposable = vscode.workspace.onDidSaveTextDocument(lint)
-        } else { // onType
-            disposable = vscode.workspace.onDidChangeTextDocument(event => lint(event.document))
-        }
+		switch (vscode.workspace.getConfiguration("selene").get<string>("run")) {
+            case "onSave": {
+                return vscode.workspace.onDidSaveTextDocument(lint)
+            }
+            case "onType": {
+                return vscode.workspace.onDidChangeTextDocument(event => lint(event.document))
+            }
+		}
     }
 
-    listenToChange()
+    let disposable = listenToChange()
     vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration("selene.run")) {
-            listenToChange()
+            disposable?.dispose()
+            disposable = listenToChange()
         }
     })
 


### PR DESCRIPTION
This feature will allow the user to specify when they want selene to lint via the VS Code extension.

This pr partially checks off [this issue](https://github.com/Kampfkarren/selene/issues/236).