### PR TITLE
Update installation.md to use branch main

### DIFF
--- a/docs/src/cli/installation.md
+++ b/docs/src/cli/installation.md
@@ -14,7 +14,7 @@ cargo install selene
 
 **If you want the most up to date version of selene**
 ```
-cargo install --git https://github.com/Kampfkarren/selene selene
+cargo install --branch main --git https://github.com/Kampfkarren/selene selene
 ```
 
 ### Roblox developers


### PR DESCRIPTION
With the switch from master to main, the default cargo install command no longer works.
It requires the branch to be manually specified.

Fixes #241 