### PR TITLE
mismatched_arg_count can now support multiple definitions, and will properly point to them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `mismatched_arg_count` now tries to find the best overlap between multiple definitions, rather than ignoring them entirely. This means that if you have `f(a)` and `f(b, c)` defined, then calling `f(1, 2, 3)` will now lint instead of silently passing, since no definition provided meets it.
+- `mismatched_arg_count` now shows all function definitions, rather than the local variable assignment. [(#259)](https://github.com/Kampfkarren/selene/issues/259)
+
 ## [0.13.0] - 2021-07-01
 ### Added
 - Added `debug.info` to the Roblox standard library. [(#260)](https://github.com/Kampfkarren/selene/issues/260)

--- a/selene-lib/tests/lints/mismatched_arg_count/definition_location.lua
+++ b/selene-lib/tests/lints/mismatched_arg_count/definition_location.lua
@@ -1,0 +1,7 @@
+local dispatch
+
+local function setDispatch()
+    dispatch = function() end
+end
+
+dispatch("foo", "bar")

--- a/selene-lib/tests/lints/mismatched_arg_count/definition_location.stderr
+++ b/selene-lib/tests/lints/mismatched_arg_count/definition_location.stderr
@@ -1,0 +1,12 @@
+error[mismatched_arg_count]: this function takes 0 arguments but 2 arguments were supplied
+  ┌─ definition_location.lua:1:1
+  │
+1 │ local dispatch
+  │ -------------- note: function defined here
+  ·
+4 │     dispatch = function() end
+  │     -------- note: function defined here
+  ·
+7 │ dispatch("foo", "bar")
+  │ ^^^^^^^^^^^^^^^^^^^^^^ expected 0 arguments
+

--- a/selene-lib/tests/lints/mismatched_arg_count/multiple_definition_locations.lua
+++ b/selene-lib/tests/lints/mismatched_arg_count/multiple_definition_locations.lua
@@ -1,0 +1,22 @@
+local dispatch
+
+if math.random() > 0.5 then
+    dispatch = function() end
+else
+    dispatch = function(a) end
+end
+
+dispatch()
+dispatch(1)
+dispatch(1, 2)
+
+local hasVararg
+
+if math.random() > 0.5 then
+    hasVararg = function(a, b, ...) end
+else
+    hasVararg = function(a, b, c, d) end
+end
+
+hasVararg(1)
+hasVararg(1, 2, 3, 4, 5)

--- a/selene-lib/tests/lints/mismatched_arg_count/multiple_definition_locations.stderr
+++ b/selene-lib/tests/lints/mismatched_arg_count/multiple_definition_locations.stderr
@@ -1,0 +1,15 @@
+error[mismatched_arg_count]: this function takes 1 argument but 2 arguments were supplied
+   ┌─ multiple_definition_locations.lua:1:1
+   │
+ 1 │ local dispatch
+   │ -------------- note: function defined here
+   ·
+ 4 │     dispatch = function() end
+   │     -------- note: function defined here
+ 5 │ else
+ 6 │     dispatch = function(a) end
+   │     -------- note: function defined here
+   ·
+11 │ dispatch(1, 2)
+   │ ^^^^^^^^^^^^^^ expected 1 argument
+

--- a/selene-lib/tests/lints/mismatched_arg_count/reassigned_variables_2.stderr
+++ b/selene-lib/tests/lints/mismatched_arg_count/reassigned_variables_2.stderr
@@ -1,0 +1,24 @@
+error[mismatched_arg_count]: this function takes 3 arguments but 4 arguments were supplied
+   ┌─ reassigned_variables_2.lua:1:16
+   │
+ 1 │ local function foo(a, b, c)
+   │                --- note: function defined here
+   ·
+ 6 │     foo = function()
+   │     --- note: function defined here
+   ·
+11 │ foo(1, 2, 3, 4)
+   │ ^^^^^^^^^^^^^^^ expected 3 arguments
+
+error[mismatched_arg_count]: this function takes 3 arguments but 4 arguments were supplied
+   ┌─ reassigned_variables_2.lua:1:16
+   │
+ 1 │ local function foo(a, b, c)
+   │                --- note: function defined here
+   ·
+ 6 │     foo = function()
+   │     --- note: function defined here
+   ·
+13 │ foo(1, 2, 3, 4)
+   │ ^^^^^^^^^^^^^^^ expected 3 arguments
+


### PR DESCRIPTION
Fixes #259