### PR TITLE
Add task library

### DIFF
--- a/selene/src/roblox/base.toml
+++ b/selene/src/roblox/base.toml
@@ -648,6 +648,41 @@ required = false
 type = "number"
 required = false
 
+[[task.defer.args]]
+type = "function"
+
+[[task.defer.args]]
+required = false
+type = "..."
+
+[[task.delay.args]]
+required = false
+type = "number"
+
+[[task.delay.args]]
+type = "function"
+
+[[task.delay.args]]
+required = false
+type = "..."
+
+[task.desynchronize]
+args = []
+
+[[task.spawn.args]]
+type = "function"
+
+[[task.spawn.args]]
+required = false
+type = "..."
+
+[task.synchronize]
+args = []
+
+[[task.wait.args]]
+required = false
+type = "number"
+
 [tick]
 args = []
 


### PR DESCRIPTION
This PR adds the new task library APIs to the Roblox std.

I wasn't sure if the convention was to include `required = false` optional for tuple arguments. Any guidance on that would be appreciated.

Something to note, both `task.delay` and `task.wait` actually take any type for their first argument. I don't know what the behavior of using another type is so I am just enforcing a `number` type.

There isn't any documentation on these APIs yet so all type information was found by just testing them since the APIs just released!