### PR TITLE
Remove cargo version note

### DIFF
--- a/docs/src/cli/installation.md
+++ b/docs/src/cli/installation.md
@@ -10,8 +10,6 @@ Once you have Rust installed, use either command:
 cargo install selene
 ```
 
-(Note: Currently, the above method will give you an outdated selene, as the selene crate on Cargo is not yet maintained.)
-
 **If you want the most up to date version of selene**
 ```
 cargo install --branch main --git https://github.com/Kampfkarren/selene selene


### PR DESCRIPTION
## Context
Currently, while new users are looking into installing selene through the cargo crate, they are met with a notice that **falsely** warns them that using `cargo install selene` will result in an out-of-date version being installed

## This PR
Removes the notice from the documentation.