### PR TITLE
Correctly handle one or two digit decimal string escapes followed by a hex digit in bad_string_escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- `bad_string_escape` now correctly handles escapes of the shape `\1a` (one or two numbers followed by a hex digit). (#292)[https://github.com/Kampfkarren/selene/issues/292]
+
 ## [0.14.0] - 2021-07-07
 ### Added
 - Added `task` library to Roblox standard library.

--- a/selene-lib/src/rules/bad_string_escape.rs
+++ b/selene-lib/src/rules/bad_string_escape.rs
@@ -125,8 +125,8 @@ impl Visitor for BadStringEscapeVisitor {
                         "a" | "b" | "f" | "n" | "r" | "t" | "v" | "\\" => {},
                         "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
                             if captures[2].len() > 1 {
-                                let hundreds = (&captures[1]).parse::<u16>().unwrap() * 100;
-                                let tens = (&captures[2][1..2]).parse::<u16>().unwrap();
+                                let hundreds = (&captures[1]).parse::<u16>().unwrap_or(0) * 100;
+                                let tens = (&captures[2][1..2]).parse::<u16>().unwrap_or(0);
                                 if hundreds + tens > 0xff {
                                     self.sequences.push(
                                         StringEscapeSequence{

--- a/selene-lib/tests/lints/bad_string_escape/lua51_string_escapes.lua
+++ b/selene-lib/tests/lints/bad_string_escape/lua51_string_escapes.lua
@@ -32,3 +32,8 @@ local bad6 = "\999"
 local bad7 = "\u{ffffffffff}"
 
 local good = [[\z\x1\u{1234\u{110000}\m\"\'\999]]
+
+-- See: Issue #292
+local decimal_decimal_hex = "\01B"
+local decimal_hex = "\1B"
+local all_hex = "\aaa"

--- a/selene-lib/tests/lints/bad_string_escape/roblox_string_escapes.lua
+++ b/selene-lib/tests/lints/bad_string_escape/roblox_string_escapes.lua
@@ -32,3 +32,8 @@ local bad6 = "\999"
 local bad7 = "\u{ffffffffff}"
 
 local good = [[\z\x1\u{1234\u{110000}\m\"\'\999]]
+
+-- See: Issue #292
+local decimal_decimal_hex = "\01B"
+local decimal_hex = "\1B"
+local all_hex = "\aaa"


### PR DESCRIPTION
This fixes #292 rather easily, though if desirable I can make a more far reaching fix that involves rewriting the regex and the match block at the end.