### PR TITLE
Fix cargo clippy && fmt

### DIFF
--- a/selene-lib/src/ast_util/visit_nodes.rs
+++ b/selene-lib/src/ast_util/visit_nodes.rs
@@ -46,6 +46,7 @@ macro_rules! make_node_visitor {
                 )+
             }
 
+            #[allow(clippy::enum_variant_names)]
             #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
             pub enum VisitorType {
                 $(
@@ -131,7 +132,7 @@ mod tests {
         }
 
         impl NodeVisitor for TestVisitor {
-            fn visit_node<'a>(&mut self, node: &'a dyn Node, _visitor_type: VisitorType) {
+            fn visit_node(&mut self, node: &dyn Node, _visitor_type: VisitorType) {
                 self.smallest_range =
                     min(self.smallest_range, node.start_position().unwrap().bytes());
                 self.largest_range = max(self.largest_range, node.end_position().unwrap().bytes());

--- a/selene-lib/src/rules/undefined_variable.rs
+++ b/selene-lib/src/rules/undefined_variable.rs
@@ -59,8 +59,7 @@ impl Rule for UndefinedVariableLint {
 
 // `...` is valid in the opening scope, but everywhere else must be explicitly defined.
 fn is_valid_vararg_reference(scope_manager: &ScopeManager, reference: &Reference) -> bool {
-    Some(reference.scope_id) == scope_manager.initial_scope
-        && reference.name == *VARARG_STRING
+    Some(reference.scope_id) == scope_manager.initial_scope && reference.name == *VARARG_STRING
 }
 
 #[cfg(test)]

--- a/selene-lib/src/standard_library.rs
+++ b/selene-lib/src/standard_library.rs
@@ -164,8 +164,7 @@ impl StandardLibrary {
 
         if let Some(meta) = &library.meta {
             if let Some(base_name) = &meta.base {
-                if let Some(base) =
-                    StandardLibrary::from_config_name(base_name, filename.parent())?
+                if let Some(base) = StandardLibrary::from_config_name(base_name, filename.parent())?
                 {
                     library.extend(base);
                 }


### PR DESCRIPTION
For some reason cargo fmt changes showed like they changed entire file where's in reality is 2 lines....
It showed better in vscode diff.