### PR TITLE
Add job to build and publish Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,32 @@ jobs:
       with:
         name: selene-light-linux
         path: ./target/release/selene
+  publish_docker_images:
+    runs-on: ubuntu-latest
+    name: Publish Docker images to Docker Hub
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v1
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: henriquehbr/selene
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
   release:
     runs-on: ubuntu-latest
-    needs: ['build_windows_light', 'build_windows', 'build_mac', 'build_mac_light', 'build_linux', 'build_linux_light']
+    needs: ['build_windows_light', 'build_windows', 'build_mac', 'build_mac_light', 'build_linux', 'build_linux_light', 'publish_docker_images']
     if: contains(github.event.head_commit.message, '[release]')
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: henriquehbr/selene
+        images: boyned/selene
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,29 +91,6 @@ jobs:
       with:
         name: selene-light-linux
         path: ./target/release/selene
-  publish_docker_images:
-    runs-on: ubuntu-latest
-    name: Publish Docker images to Docker Hub
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v1
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: henriquehbr/selene
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
   release:
     runs-on: ubuntu-latest
     needs: ['build_windows_light', 'build_windows', 'build_mac', 'build_mac_light', 'build_linux', 'build_linux_light', 'publish_docker_images']
@@ -207,3 +184,21 @@ jobs:
         asset_path: ./selene-light-macos.zip
         asset_name: selene-light-${{ env.VERSION }}-macos.zip
         asset_content_type: application/zip
+    - uses: actions/checkout@v1
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: henriquehbr/selene
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         path: ./target/release/selene
   release:
     runs-on: ubuntu-latest
-    needs: ['build_windows_light', 'build_windows', 'build_mac', 'build_mac_light', 'build_linux', 'build_linux_light', 'publish_docker_images']
+    needs: ['build_windows_light', 'build_windows', 'build_mac', 'build_mac_light', 'build_linux', 'build_linux_light']
     if: contains(github.event.head_commit.message, '[release]')
     steps:
     - uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,15 @@ RUN apk add g++ && \
     cargo install --no-default-features --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM bash AS selene
-COPY --from=selene-builder /usr/local/carg/bin/selene /
+COPY --from=selene-builder /usr/local/cargo/bin/selene /
 CMD ["/selene"]
 
 FROM bash AS selene-light
-COPY --from=selene-light-builder /usr/local/carg/bin/selene /
+COPY --from=selene-light-builder /usr/local/cargo/bin/selene /
 CMD ["/selene"]
 
 FROM bash AS selene-musl
-COPY --from=selene-musl-builder /usr/local/carg/bin/selene /
+COPY --from=selene-musl-builder /usr/local/cargo/bin/selene /
 CMD ["/selene"]
 
 FROM bash AS selene-light-musl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
 FROM rust:1.56-bullseye AS selene-builder
-
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install g++ && \
     cargo install --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM rust:1.56-bullseye AS selene-light-builder
-
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install g++ && \
     cargo install --no-default-features --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM rust:1.56-alpine3.14 AS selene-musl-builder
-
 RUN apk add g++ && \
     cargo install --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM rust:1.56-alpine3.14 AS selene-light-musl-builder
-
 RUN apk add g++ && \
     cargo install --no-default-features --branch main --git https://github.com/Kampfkarren/selene selene
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,24 @@ FROM rust:1.56-bullseye AS selene-builder
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install g++ && \
-    cargo install selene
+    cargo install --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM rust:1.56-bullseye AS selene-light-builder
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install g++ && \
-    cargo install --no-default-features selene
+    cargo install --no-default-features --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM rust:1.56-alpine3.14 AS selene-musl-builder
 
 RUN apk add g++ && \
-    cargo install selene
+    cargo install --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM rust:1.56-alpine3.14 AS selene-light-musl-builder
 
 RUN apk add g++ && \
-    cargo install --no-default-features selene
+    cargo install --no-default-features --branch main --git https://github.com/Kampfkarren/selene selene
 
 FROM bash AS selene
 COPY --from=selene-builder /usr/local/carg/bin/selene /


### PR DESCRIPTION
I'm not 100% sure if this might work at first, as i mentioned earlier, i'm a fish out of water when it comes to setting up CI/CD environments, but feel free to test it and report any issue or inconsistency you find might here, and i'll fix it asap

Probably, something that we should have to look further is regarding the image tags and if they are properly being detected and pushed to Docker Hub, i've read [docker-metadata-action](https://github.com/marketplace/actions/docker-metadata-action) but couldn't find exactly where `${{ steps.meta.outputs.tags }}` points to or how we can make sure all the 4 tags get detected:

- `selene:latest`
- `selene:light-latest`
- `selene:musl-latest`
- `selene:musl-light-latest`

> Also, i made some other minor changes to the Dockerfile, removed the spaces separating the build stages to made them look visually more grouped together, and also specified `cargo` to use the `main` branch as source instead of fetching from [crates.io](https://crates.io)