### PR TITLE
Add gcinfo function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `Vector2.zero`, `Vector2.one`, `Vector2.xAxis`, `Vector2.yAxis` to the Roblox standard library.
 - Added `Vector3.zero`, `Vector3.one`, `Vector3.xAxis`, `Vector3.yAxis`, `Vector3.zAxis` to the Roblox standard library.
 - Added `CFrame.identity` to the Roblox standard library.
+- Added `gcinfo` to the Roblox standard library.
 
 ### Fixed
 - Fixed a bug where empty else blocks were not properly closing their scope, meaning that they could confuse the shadowing lint. [(#116)](https://github.com/Kampfkarren/selene/issues/116)

--- a/selene/src/roblox/base.toml
+++ b/selene/src/roblox/base.toml
@@ -444,6 +444,9 @@ required = false
 [[Faces.new.args]]
 type = "..."
 
+[gcinfo]
+args = []
+
 [[Instance.new.args]]
 type = "string" # This is changed at generate time
 


### PR DESCRIPTION
Adds the `gcinfo()` function global. It is not deprecated in Roblox since Luau gutted the would-be superseding `collectgarbage()` function due to [sandboxing](https://luau-lang.org/sandbox).