### PR TITLE
vscode: Path settings to be per-machine scope

### DIFF
--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -41,7 +41,8 @@
                         null
                     ],
                     "default": null,
-                    "description": "Specifies the path of selene. If not specified, selene will automatically download from the GitHub releases."
+                    "description": "Specifies the path of selene. If not specified, selene will automatically download from the GitHub releases.",
+                    "scope": "machine-overridable"
                 },
                 "selene.run": {
                     "title": "Run",


### PR DESCRIPTION
The current scope of the path in the VSCode extension doesn't play too nicely when using the sync feature on across different OSes.

Example would be using selene via Foreman on Windows, then set the path settings to use the Windows path would result in breaking the extension when using MacOS or Linux (i.e. Codespaces) with syncing enabled and editing to work on different OSes would result in messing up the Windows machine.