### PR TITLE
Fix bit32.replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed display style option triggering `ArgumentConflict` when using quiet option. [(#288)](https://github.com/Kampfkarren/selene/issues/288)
 - `bad_string_escape` now correctly handles escapes of the shape `\1a` (one or two numbers followed by a hex digit). [(#292)](https://github.com/Kampfkarren/selene/issues/292)
 - Fixed Roblox types not counting towards usage. [(#270)](https://github.com/Kampfkarren/selene/issues/270)
+- Fixed incorrect number of paremeters for `bit32.replace`
 
 ### Changed
 - `duplicate_keys` now has a error severity. [(#262)](https://github.com/Kampfkarren/selene/issues/262)

--- a/selene/src/roblox/base.toml
+++ b/selene/src/roblox/base.toml
@@ -69,6 +69,9 @@ type = "number"
 
 [[bit32.replace.args]]
 type = "number"
+
+[[bit32.replace.args]]
+type = "number"
 required = false
 
 [[bit32.lrotate.args]]


### PR DESCRIPTION
`bit32.replace` has 4 parameters, but only 3 have been added to `base.toml` (one is missing).

This PR fixes that by adding the additional parameter to `base.toml`. If I missed anything (this is my first PR) please let me know.

### Current:
(top is RobloxLSP, you can see the selene warning on the bottom)
![Current](https://user-images.githubusercontent.com/55821122/150906822-a0bcce8f-88ad-4350-bc35-e2c109029ba5.png)


### Expected:
![Expected](https://user-images.githubusercontent.com/55821122/150906565-80061bf1-d575-4684-a614-8e049b5ffed0.png)
