### PR TITLE
Add line/col locations to JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Unreleased
+## Unreleased
 ### Added
 - Added `start_line`, `start_column`, `end_line`, and `end_column` to JSON diagnostic output.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Unreleased
+### Added
+- Added `start_line`, `start_column`, `end_line`, and `end_column` to JSON diagnostic output.
+
 ## [0.16.0] - 2022-01-30
 ### Added
 - Added support for parsing generic type packs, variadic type packs, and explicit type packs in generic arguments for a type under the `roblox` feature flag (`type X<S...> = Y<(string, number), ...string, S...>`)

--- a/selene/src/json_output.rs
+++ b/selene/src/json_output.rs
@@ -22,33 +22,54 @@ struct Label {
 #[derive(Serialize)]
 struct Span {
     start: usize,
+    start_line: usize,
+    start_column: usize,
     end: usize,
+    end_line: usize,
+    end_column: usize,
 }
 
-fn label_to_serializable<T>(label: &CodespanLabel<T>) -> Label {
+fn label_to_serializable(
+    label: &CodespanLabel<codespan::FileId>,
+    files: &codespan::Files<&str>,
+) -> Label {
+    let start_location = files
+        .location(label.file_id, label.range.start as u32)
+        .expect("unable to determine start location for label");
+    let end_location = files
+        .location(label.file_id, label.range.end as u32)
+        .expect("unable to determine end location for label");
     Label {
         message: label.message.to_owned(),
         span: Span {
             start: label.range.start,
+            start_line: start_location.line.into(),
+            start_column: start_location.column.into(),
             end: label.range.end,
+            end_line: end_location.line.into(),
+            end_column: end_location.column.into(),
         },
     }
 }
 
 pub fn diagnostic_to_json(
     diagnostic: &CodespanDiagnostic<codespan::FileId>,
+    files: &codespan::Files<&str>,
 ) -> serde_json::Result<String> {
     serde_json::to_string(&JsonDiagnostic {
         code: diagnostic.code.to_owned(),
         message: diagnostic.message.to_owned(),
         severity: diagnostic.severity.to_owned(),
         notes: diagnostic.notes.to_owned(),
-        primary_label: label_to_serializable(diagnostic.labels.first().expect("no labels passed")),
+        primary_label: label_to_serializable(
+            diagnostic.labels.first().expect("no labels passed"),
+            files,
+        ),
         secondary_labels: diagnostic
             .labels
             .iter()
             .filter(|label| label.style == LabelStyle::Secondary)
-            .map(label_to_serializable)
+            .map(|label| label_to_serializable(label, files))
             .collect(),
     })
 }

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -115,7 +115,7 @@ fn emit_codespan(
         writeln!(
             writer,
             "{}",
-            json_output::diagnostic_to_json(diagnostic).unwrap()
+            json_output::diagnostic_to_json(diagnostic, files).unwrap()
         )
         .unwrap();
     } else {


### PR DESCRIPTION
Hi! I wanted to add Selene support to ALE for Vim/Neovim but it would be a lot easier to do if line/column were reported in the JSON output, so I took a stab at doing it. It's been a while since I've worked with Rust so I'm sure this is a mess and needs a lot of work - this is literally the first thing I got to compile. 😄