### PR TITLE
Add `--no-summary` option to suppress summary info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Added `debug.resetmemorycategory` to the Roblox standard library.
 - Added `debug.setmemorycategory` to the Roblox standard library.
+- Added `--no-summary` option to suppress summary information.
 
 ## [0.17.0] - 2022-04-10
 ### Added

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -4,20 +4,28 @@ If you want to get a quick understanding of the interface, simply type `selene -
 ```
 USAGE:
     selene [FLAGS] [OPTIONS] <files>...
+    selene <SUBCOMMAND>
 
 FLAGS:
-    -h, --help       Prints help information
-    -q               Display only the necessary information
-    -V, --version    Prints version information
+    -h, --help          Prints help information
+    -n, --no-summary    Suppress summary information
+    -q, --quiet         Display only the necessary information. Equivalent to --display-style="quiet"
+    -V, --version       Prints version information
 
 OPTIONS:
-        --config <config>              A toml file to configure the behavior of selene [default: selene.toml]
-        --num-threads <num-threads>    Number of threads to run on, default to the numbers of logical cores on your
-                                       system [default: 8]
-        --pattern <pattern>            A glob to match files with to check [default: **/*.lua]
+        --color <color>                     [default: auto]  [possible values: Always, Auto, Never]
+        --config <config>                  A toml file to configure the behavior of selene [default: selene.toml]
+        --display-style <display-style>    Sets the display method [possible values: Json, Rich, Quiet]
+        --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
+                                           system [default: 6]
+        --pattern <pattern>                A glob to match files with to check [default: **/*.lua]
 
 ARGS:
     <files>...
+
+SUBCOMMANDS:
+    generate-roblox-std
+    help                   Prints this message or the help of the given subcommand(s)
 ```
 
 ## Basic usage

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -17,7 +17,7 @@ OPTIONS:
         --config <config>                  A toml file to configure the behavior of selene [default: selene.toml]
         --display-style <display-style>    Sets the display method [possible values: Json, Rich, Quiet]
         --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
-                                           system [default: 6]
+                                           system [default: your system's cores]
         --pattern <pattern>                A glob to match files with to check [default: **/*.lua]
 
 ARGS:

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -102,7 +102,7 @@ export async function activate(
 
         const output = await selene.seleneCommand(
             context.globalStorageUri,
-            "--display-style=json -",
+            "--display-style=json --no-summary -",
             selene.Expectation.Stderr,
             vscode.workspace.getWorkspaceFolder(document.uri),
             document.getText(),
@@ -118,10 +118,6 @@ export async function activate(
         const byteOffsets = new Set<number>()
 
         for (const line of output.split("\n")) {
-            if (line === "Results:") {
-                break
-            }
-
             const data: Diagnostic = JSON.parse(line)
             dataToAdd.push(data)
             byteOffsets.add(data.primary_label.span.start)

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -539,7 +539,7 @@ fn start(matches: opts::Options) {
         LINT_WARNINGS.load(Ordering::SeqCst),
     );
 
-    if !matches.luacheck {
+    if !matches.luacheck && !matches.no_summary {
         log_total(parse_errors, lint_errors, lint_warnings).ok();
     }
 

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -47,6 +47,10 @@ pub struct Options {
     )]
     pub color: Color,
 
+    /// Suppress summary information.
+    #[structopt(long, short)]
+    pub no_summary: bool,
+
     /// Whether to pretend to be luacheck for existing consumers
     #[structopt(long, hidden(true))]
     pub luacheck: bool,


### PR DESCRIPTION
I noticed there's no way to suppress summary information which means parsing JSON output requires more than just using `JSON.parse` (or equivalent) on each line of output. This PR adds a `--no-summary` option to suppress summary information.