### PR TITLE
Add stdin information to CLI usage documentation

### DIFF
--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -38,6 +38,8 @@ If you just want to check one file: `selene code.lua`
 
 If you want to check multiple files/folders: `selene file1 file2 file3 ...`
 
+If you want to pipe code to Selene using stdin: `cat code.lua | selene -`
+
 ## Advanced options
 
 **-q**

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -38,7 +38,7 @@ If you just want to check one file: `selene code.lua`
 
 If you want to check multiple files/folders: `selene file1 file2 file3 ...`
 
-If you want to pipe code to Selene using stdin: `cat code.lua | selene -`
+If you want to pipe code to selene using stdin: `cat code.lua | selene -`
 
 ## Advanced options
 


### PR DESCRIPTION
I was going to add a `--stdin` option to do this, but noticed in the code it's already possible using `selene -`.