### PR TITLE
Add missing Roblox datatype constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
 - Added [`utf8` globals](https://q-syshelp.qsc.com/Content/Control_Scripting/Lua_5.3_Reference_Manual/Standard_Libraries/4_-_Basic_UTF-8_Support.htm) to the builtin `lua53` standard library.
+- Added Roblox datatype constructors `CatalogSearchParams.new`, `FloatCurveKey.new`, and `RotationCurveKey.new`.
 
 ## [0.19.1] - 2022-06-22
 ### Fixed

--- a/selene/src/roblox/base.yml
+++ b/selene/src/roblox/base.yml
@@ -361,6 +361,7 @@ globals:
           display: CFrame
       - type:
           display: KeyInterpolationMode
+    must_use: true
   TweenInfo.new:
     args:
       - required: false

--- a/selene/src/roblox/base.yml
+++ b/selene/src/roblox/base.yml
@@ -45,6 +45,9 @@ globals:
   BrickColor.random:
     args: []
     must_use: true
+  CatalogSearchParams.new:
+    args: []
+    must_use: true
   CFrame.Angles:
     args:
       - required: false
@@ -255,6 +258,13 @@ globals:
   Faces.new:
     args:
       - type: "..."
+    must_use: true
+  FloatCurveKey.new:
+    args:
+      - type: number
+      - type: number
+      - type:
+          display: KeyInterpolationMode
     must_use: true
   Instance.new:
     args:

--- a/selene/src/roblox/base.yml
+++ b/selene/src/roblox/base.yml
@@ -354,6 +354,13 @@ globals:
         type:
           display: Vector3
     must_use: true
+  RotationCurveKey.new:
+    args:
+      - type: number
+      - type:
+          display: CFrame
+      - type:
+          display: KeyInterpolationMode
   TweenInfo.new:
     args:
       - required: false


### PR DESCRIPTION
Closes #384.

Some functions weren't linting because they weren't in `roblox.yml`, so I added the following functions to selene's `roblox/base.yml`.

* `CatalogSearchParams.new`
* `FloatCurveKey.new`
* `RotationCurveKey.new`