### PR TITLE
Match .luau filename extension by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Match `.luau` filename extension by default.
+- Allow multiple comma-separated glob patterns with `--patterns` rather than `--pattern`.
+
 ## [0.20.0] - 2022-07-21
 ### Added
 - Added [`utf8` globals](https://q-syshelp.qsc.com/Content/Control_Scripting/Lua_5.3_Reference_Manual/Standard_Libraries/4_-_Basic_UTF-8_Support.htm) to the builtin `lua53` standard library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Match `.luau` filename extension by default.
-- Allow multiple comma-separated glob patterns with `--patterns` rather than `--pattern`.
+- Allow multiple comma-separated glob patterns with `--pattern`.
 
 ## [0.20.0] - 2022-07-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Match `.luau` filename extension by default.
-- Allow multiple comma-separated glob patterns with `--pattern`.
+- Allow `--pattern` to be passed multiple times.
 
 ## [0.20.0] - 2022-07-21
 ### Added

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -1,5 +1,4 @@
 # CLI Usage
-
 If you want to get a quick understanding of the interface, simply type `selene --help`.
 
 ```
@@ -19,7 +18,7 @@ OPTIONS:
         --display-style <display-style>    Sets the display method [possible values: Json, Rich, Quiet]
         --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
                                            system [default: your system's cores]
-        --patterns <patterns>              Comma-separated globs to match files to check [default: **/*.lua,**/*.luau]
+        --pattern <pattern>              Comma-separated globs to match files to check [default: **/*.lua,**/*.luau]
 
 ARGS:
     <files>...
@@ -73,10 +72,10 @@ Results:
 0 parse errors
 ```
 
-**--num-threads** _num-threads_
+**--num-threads** *num-threads*
 
 Specifies the number of threads for selene to use. Defaults to however many cores your CPU has. If you type `selene --help`, you can see this number because it will show as the default for you.
 
-**--patterns** _patterns_
+**--pattern** *pattern*
 
-Comma-separated [globs](<https://en.wikipedia.org/wiki/Glob_(programming)>) to match what files selene should check for. For example, if you only wanted to check files that end with `.spec.lua`, you would input `--patterns **/*.spec.lua`. Defaults to `**/*.lua,**/*.luau`, meaning "any lua/luau file".
+Comma-separated [globs](https://en.wikipedia.org/wiki/Glob_(programming)) to match what files selene should check for. For example, if you only wanted to check files that end with `.spec.lua`, you would input `--pattern **/*.spec.lua`. Defaults to `**/*.lua`, meaning "any lua file", or `**/*.lua,**/*.luau` with the roblox feature flag, meaning "any lua/luau file".

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -17,8 +17,8 @@ OPTIONS:
         --config <config>                  A toml file to configure the behavior of selene [default: selene.toml]
         --display-style <display-style>    Sets the display method [possible values: Json, Rich, Quiet]
         --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
-                                           system [default: your system's cores]
-        --pattern <pattern>              Comma-separated globs to match files to check [default: **/*.lua,**/*.luau]
+                                           system [default: 4]
+        --pattern <pattern>                A glob to match files with to check [default: **/*.lua**/*.luau]
 
 ARGS:
     <files>...
@@ -26,6 +26,8 @@ ARGS:
 SUBCOMMANDS:
     generate-roblox-std
     help                   Prints this message or the help of the given subcommand(s)
+    update-roblox-std
+    upgrade-std
 ```
 
 ## Basic usage

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -80,4 +80,4 @@ Specifies the number of threads for selene to use. Defaults to however many core
 
 **--pattern** *pattern*
 
-Comma-separated [globs](https://en.wikipedia.org/wiki/Glob_(programming)) to match what files selene should check for. For example, if you only wanted to check files that end with `.spec.lua`, you would input `--pattern **/*.spec.lua`. Defaults to `**/*.lua`, meaning "any lua file", or `**/*.lua,**/*.luau` with the roblox feature flag, meaning "any lua/luau file".
+A [glob](https://en.wikipedia.org/wiki/Glob_(programming)) to match what files selene should check for. For example, if you only wanted to check files that end with `.spec.lua`, you would input `--pattern **/*.spec.lua`. Defaults to `**/*.lua`, meaning "any lua file", or `**/*.lua` and `**/*.luau` with the roblox feature flag, meaning "any lua/luau file".

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -17,8 +17,8 @@ OPTIONS:
         --config <config>                  A toml file to configure the behavior of selene [default: selene.toml]
         --display-style <display-style>    Sets the display method [possible values: Json, Rich, Quiet]
         --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
-                                           system [default: 4]
-        --pattern <pattern>                A glob to match files with to check [default: **/*.lua**/*.luau]
+                                           system [default: your system's cores]
+        --pattern <pattern>                A glob to match files with to check
 
 ARGS:
     <files>...

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -1,4 +1,5 @@
 # CLI Usage
+
 If you want to get a quick understanding of the interface, simply type `selene --help`.
 
 ```
@@ -18,7 +19,7 @@ OPTIONS:
         --display-style <display-style>    Sets the display method [possible values: Json, Rich, Quiet]
         --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
                                            system [default: your system's cores]
-        --pattern <pattern>                A glob to match files with to check [default: **/*.lua]
+        --patterns <patterns>              Comma-separated globs to match files to check [default: **/*.lua,**/*.luau]
 
 ARGS:
     <files>...
@@ -72,10 +73,10 @@ Results:
 0 parse errors
 ```
 
-**--num-threads** *num-threads*
+**--num-threads** _num-threads_
 
 Specifies the number of threads for selene to use. Defaults to however many cores your CPU has. If you type `selene --help`, you can see this number because it will show as the default for you.
 
-**--pattern** *pattern*
+**--patterns** _patterns_
 
-A [glob](https://en.wikipedia.org/wiki/Glob_(programming)) to match what files selene should check for. For example, if you only wanted to check files that end with `.spec.lua`, you would input `--pattern **/*.spec.lua`. Defaults to `**/*.lua`, meaning "any lua file".
+Comma-separated [globs](<https://en.wikipedia.org/wiki/Glob_(programming)>) to match what files selene should check for. For example, if you only wanted to check files that end with `.spec.lua`, you would input `--patterns **/*.spec.lua`. Defaults to `**/*.lua,**/*.luau`, meaning "any lua/luau file".

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -485,7 +485,7 @@ fn start(matches: opts::Options) {
 
                     pool.execute(move || read_file(&checker, Path::new(&filename)));
                 } else if metadata.is_dir() {
-                    for pattern in matches.patterns.split(',') {
+                    for pattern in &matches.pattern.vec {
                         let glob = match glob::glob(&format!(
                             "{}/{}",
                             filename.to_string_lossy(),

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -347,8 +347,14 @@ fn read_file(checker: &Checker<toml::value::Value>, filename: &Path) {
     );
 }
 
-fn start(matches: opts::Options) {
+fn start(mut matches: opts::Options) {
     *OPTIONS.write().unwrap() = Some(matches.clone());
+
+    if matches.pattern.is_empty() {
+        matches.pattern.push(String::from("**/*.lua"));
+        #[cfg(feature = "roblox")]
+        matches.pattern.push(String::from("**/*.luau"));
+    }
 
     match matches.command {
         #[cfg(feature = "roblox")]
@@ -485,7 +491,7 @@ fn start(matches: opts::Options) {
 
                     pool.execute(move || read_file(&checker, Path::new(&filename)));
                 } else if metadata.is_dir() {
-                    for pattern in &matches.pattern.vec {
+                    for pattern in &matches.pattern {
                         let glob = match glob::glob(&format!(
                             "{}/{}",
                             filename.to_string_lossy(),

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -7,9 +7,9 @@ use structopt::{clap::arg_enum, StructOpt};
 #[structopt(setting(structopt::clap::AppSettings::ArgsNegateSubcommands))]
 #[structopt(setting(structopt::clap::AppSettings::SubcommandsNegateReqs))]
 pub struct Options {
-    /// A glob to match files with to check
-    #[structopt(long, default_value = "**/*.lua")]
-    pub pattern: String,
+    /// Comma-separated globs to match files to check
+    #[structopt(long, default_value = "**/*.lua,**/*.luau")]
+    pub patterns: String,
 
     /// A toml file to configure the behavior of selene [default: selene.toml]
     // .default is not used here since if the user explicitly specifies the config file

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -8,7 +8,8 @@ use structopt::{clap::arg_enum, StructOpt};
 #[structopt(setting(structopt::clap::AppSettings::SubcommandsNegateReqs))]
 pub struct Options {
     /// Comma-separated globs to match files to check
-    #[structopt(long, default_value = "**/*.lua,**/*.luau")]
+    #[cfg_attr(feature = "roblox", structopt(long, default_value = "**/*.lua,**/*.luau"))]
+    #[cfg_attr(not(feature = "roblox"), structopt(long, default_value = "**/*.lua"))]
     pub patterns: String,
 
     /// A toml file to configure the behavior of selene [default: selene.toml]

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -1,21 +1,6 @@
-use std::{ffi::OsString, path::PathBuf, str::FromStr};
+use std::{ffi::OsString, path::PathBuf};
 
 use structopt::{clap::arg_enum, StructOpt};
-
-#[derive(Clone, Debug)]
-pub struct Patterns {
-    pub vec: Vec<String>,
-}
-
-impl FromStr for Patterns {
-    type Err = Box<dyn std::error::Error>;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Patterns {
-            vec: s.split('\0').map(|x| x.to_string()).collect(),
-        })
-    }
-}
 
 #[derive(Clone, Debug, StructOpt)]
 #[structopt(rename_all = "kebab-case")]
@@ -23,12 +8,8 @@ impl FromStr for Patterns {
 #[structopt(setting(structopt::clap::AppSettings::SubcommandsNegateReqs))]
 pub struct Options {
     /// A glob to match files with to check
-    #[cfg_attr(
-        feature = "roblox",
-        structopt(long, default_value = "**/*.lua\0**/*.luau")
-    )]
-    #[cfg_attr(not(feature = "roblox"), structopt(long, default_value = "**/*.lua"))]
-    pub pattern: Patterns,
+    #[structopt(long)]
+    pub pattern: Vec<String>,
 
     /// A toml file to configure the behavior of selene [default: selene.toml]
     // .default is not used here since if the user explicitly specifies the config file

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -1,19 +1,34 @@
-use std::{ffi::OsString, path::PathBuf};
+use std::{ffi::OsString, path::PathBuf, str::FromStr};
 
 use structopt::{clap::arg_enum, StructOpt};
+
+#[derive(Clone, Debug)]
+pub struct Patterns {
+    pub vec: Vec<String>,
+}
+
+impl FromStr for Patterns {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Patterns {
+            vec: s.split('\0').map(|x| x.to_string()).collect(),
+        })
+    }
+}
 
 #[derive(Clone, Debug, StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 #[structopt(setting(structopt::clap::AppSettings::ArgsNegateSubcommands))]
 #[structopt(setting(structopt::clap::AppSettings::SubcommandsNegateReqs))]
 pub struct Options {
-    /// Comma-separated globs to match files to check
+    /// A glob to match files with to check
     #[cfg_attr(
         feature = "roblox",
-        structopt(long, default_value = "**/*.lua,**/*.luau")
+        structopt(long, default_value = "**/*.lua\0**/*.luau")
     )]
     #[cfg_attr(not(feature = "roblox"), structopt(long, default_value = "**/*.lua"))]
-    pub patterns: String,
+    pub pattern: Patterns,
 
     /// A toml file to configure the behavior of selene [default: selene.toml]
     // .default is not used here since if the user explicitly specifies the config file

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -8,7 +8,10 @@ use structopt::{clap::arg_enum, StructOpt};
 #[structopt(setting(structopt::clap::AppSettings::SubcommandsNegateReqs))]
 pub struct Options {
     /// Comma-separated globs to match files to check
-    #[cfg_attr(feature = "roblox", structopt(long, default_value = "**/*.lua,**/*.luau"))]
+    #[cfg_attr(
+        feature = "roblox",
+        structopt(long, default_value = "**/*.lua,**/*.luau")
+    )]
     #[cfg_attr(not(feature = "roblox"), structopt(long, default_value = "**/*.lua"))]
     pub patterns: String,
 


### PR DESCRIPTION
Closes #325.
It seems like the glob crate doesn't allow pattern lists like `**/*.{lua,luau}` (see [docs](https://docs.rs/glob/latest/glob/struct.Pattern.html)), so I chose to match multiple patterns instead. ~~I also renamed `--pattern` to `--patterns` to match the change, let me know if that's not okay.~~