### PR TITLE
Fixes three separate lints incorrectly handling overriding functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.20.0...HEAD)
 
+### Added
+- `undefined_variable` now properly catches `global` as undefined in `function global.name()`.
+
 ### Changed
 - Match `.luau` filename extension by default.
 - Allow `--pattern` to be passed multiple times.
 
 ### Fixed
 - Fixed `unused_variable` incorrectly tagging `function global.name()` when `global` is defined in the standard library.
+- Fixed `unscoped_variables` incorrectly tagging `function global.name()` as creating an unscoped variable for `global`.
 
 ## [0.20.0](https://github.com/Kampfkarren/selene/releases/tag/0.20.0) - 2022-07-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.20.0...HEAD)
 
 ### Changed
-
 - Match `.luau` filename extension by default.
 - Allow `--pattern` to be passed multiple times.
+
+### Fixed
+- Fixed `unused_variable` incorrectly tagging `function global.name()` when `global` is defined in the standard library.
 
 ## [0.20.0](https://github.com/Kampfkarren/selene/releases/tag/0.20.0) - 2022-07-21
 ### Added

--- a/selene-lib/src/lib.rs
+++ b/selene-lib/src/lib.rs
@@ -20,6 +20,9 @@ mod util;
 #[cfg(test)]
 mod test_util;
 
+#[cfg(test)]
+mod test_full_runs;
+
 use rules::{AstContext, Context, Diagnostic, Rule, Severity};
 use standard_library::StandardLibrary;
 

--- a/selene-lib/src/lint_filtering.rs
+++ b/selene-lib/src/lint_filtering.rs
@@ -104,7 +104,7 @@ impl NodeVisitor for FilterVisitor {
 
             self.comments_checked.insert(hash);
 
-            for comment in match &*trivia.token_type() {
+            for comment in match trivia.token_type() {
                 TokenType::SingleLineComment { comment } => comment,
                 TokenType::MultiLineComment { comment, .. } => comment,
                 _ => continue,

--- a/selene-lib/src/rules/mismatched_arg_count.rs
+++ b/selene-lib/src/rules/mismatched_arg_count.rs
@@ -378,7 +378,7 @@ impl MismatchedArgCountVisitor<'_> {
             .copied()
             .chain(variable.references.iter().filter_map(|reference_id| {
                 let reference = self.scope_manager.references.get(*reference_id)?;
-                if reference.write {
+                if reference.write.is_some() {
                     Some(reference.identifier)
                 } else {
                     None

--- a/selene-lib/src/rules/roblox_incorrect_roact_usage.rs
+++ b/selene-lib/src/rules/roblox_incorrect_roact_usage.rs
@@ -94,7 +94,7 @@ impl IncorrectRoactUsageVisitor {
         &mut self,
         token: &TokenReference,
     ) -> Option<&'static rbx_reflection::RbxClassDescriptor> {
-        let name = if let TokenType::StringLiteral { literal, .. } = &*token.token_type() {
+        let name = if let TokenType::StringLiteral { literal, .. } = token.token_type() {
             literal.to_string()
         } else {
             return None;

--- a/selene-lib/src/rules/test_util.rs
+++ b/selene-lib/src/rules/test_util.rs
@@ -1,5 +1,8 @@
 use super::{AstContext, Context, Rule};
-use crate::{standard_library::v1, test_util::PrettyString, StandardLibrary};
+use crate::{
+    test_util::{get_standard_library, PrettyString},
+    StandardLibrary,
+};
 use std::{
     fs,
     io::Write,
@@ -43,14 +46,8 @@ pub fn test_lint_config<
 ) {
     let path_base = TEST_PROJECTS_ROOT.join(lint_name).join(test_name);
 
-    if let Ok(test_std_toml_contents) = fs::read_to_string(path_base.with_extension("std.toml")) {
-        config.standard_library = toml::from_str::<v1::StandardLibrary>(&test_std_toml_contents)
-            .unwrap()
-            .into();
-    } else if let Ok(test_std_yml_contents) =
-        fs::read_to_string(path_base.with_extension("std.yml"))
-    {
-        config.standard_library = serde_yaml::from_str(&test_std_yml_contents).unwrap();
+    if let Some(standard_library) = get_standard_library(&path_base) {
+        config.standard_library = standard_library;
     }
 
     let lua_source =

--- a/selene-lib/src/rules/undefined_variable.rs
+++ b/selene-lib/src/rules/undefined_variable.rs
@@ -77,6 +77,15 @@ mod tests {
     }
 
     #[test]
+    fn test_function_overriding() {
+        test_lint(
+            UndefinedVariableLint::new(()).unwrap(),
+            "undefined_variable",
+            "function_overriding",
+        );
+    }
+
+    #[test]
     fn test_hoisting() {
         test_lint(
             UndefinedVariableLint::new(()).unwrap(),

--- a/selene-lib/src/rules/unscoped_variables.rs
+++ b/selene-lib/src/rules/unscoped_variables.rs
@@ -1,3 +1,5 @@
+use crate::ast_util::scopes::ReferenceWrite;
+
 use super::*;
 use std::collections::HashSet;
 
@@ -44,7 +46,7 @@ impl Rule for UnscopedVariablesLint {
 
         for (_, reference) in &ast_context.scope_manager.references {
             if reference.resolved.is_none()
-                && reference.write
+                && reference.write == Some(ReferenceWrite::Assign)
                 && !read.contains(&reference.identifier)
                 && !self.ignore_pattern.is_match(&reference.name)
                 && !context.standard_library.global_has_fields(&reference.name)
@@ -69,6 +71,15 @@ impl Rule for UnscopedVariablesLint {
 #[cfg(test)]
 mod tests {
     use super::{super::test_util::*, *};
+
+    #[test]
+    fn test_function_overriding() {
+        test_lint(
+            UnscopedVariablesLint::new(UnscopedVariablesConfig::default()).unwrap(),
+            "unscoped_variables",
+            "function_overriding",
+        );
+    }
 
     #[test]
     fn test_unscoped_variables() {

--- a/selene-lib/src/rules/unused_variable.rs
+++ b/selene-lib/src/rules/unused_variable.rs
@@ -60,6 +60,10 @@ impl Rule for UnusedVariableLint {
             .iter()
             .filter(|(_, variable)| !self.ignore_pattern.is_match(&variable.name))
         {
+            if context.standard_library.global_has_fields(&variable.name) {
+                continue;
+            }
+
             let references = variable
                 .references
                 .iter()
@@ -212,6 +216,15 @@ mod tests {
             UnusedVariableLint::new(UnusedVariableConfig::default()).unwrap(),
             "unused_variable",
             "explicit_self",
+        );
+    }
+
+    #[test]
+    fn test_function_overriding() {
+        test_lint(
+            UnusedVariableLint::new(UnusedVariableConfig::default()).unwrap(),
+            "unused_variable",
+            "function_overriding",
         );
     }
 

--- a/selene-lib/src/rules/unused_variable.rs
+++ b/selene-lib/src/rules/unused_variable.rs
@@ -73,7 +73,7 @@ impl Rule for UnusedVariableLint {
             // We need to make sure that references that are marked as "read" aren't only being read in an "observes: write" context.
             let analyzed_references = references
                 .map(|reference| {
-                    if reference.write {
+                    if reference.write.is_some() {
                         return AnalyzedReference::PlainWrite;
                     }
 

--- a/selene-lib/src/rules/unused_variable.rs
+++ b/selene-lib/src/rules/unused_variable.rs
@@ -30,7 +30,7 @@ pub struct UnusedVariableLint {
     ignore_pattern: Regex,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AnalyzedReference {
     Read,
     PlainWrite,

--- a/selene-lib/src/test_full_runs.rs
+++ b/selene-lib/src/test_full_runs.rs
@@ -1,0 +1,10 @@
+use crate::{test_util::test_full_run_config, CheckerConfig};
+
+#[test]
+fn function_overriding() {
+    test_full_run_config(
+        "function_overriding",
+        "function_overriding",
+        CheckerConfig::default(),
+    );
+}

--- a/selene-lib/tests/full_run/function_overriding/function_overriding.lua
+++ b/selene-lib/tests/full_run/function_overriding/function_overriding.lua
@@ -1,0 +1,4 @@
+-- This breaks like, 3 separate lints
+function global.name() end
+
+function defined.name() end

--- a/selene-lib/tests/full_run/function_overriding/function_overriding.std.yml
+++ b/selene-lib/tests/full_run/function_overriding/function_overriding.std.yml
@@ -1,0 +1,3 @@
+globals:
+  defined:
+    any: true

--- a/selene-lib/tests/full_run/function_overriding/function_overriding.stderr
+++ b/selene-lib/tests/full_run/function_overriding/function_overriding.stderr
@@ -1,0 +1,6 @@
+error[undefined_variable]: `global` is not defined
+  ┌─ function_overriding.lua:2:10
+  │
+2 │ function global.name() end
+  │          ^^^^^^
+

--- a/selene-lib/tests/lints/undefined_variable/function_overriding.lua
+++ b/selene-lib/tests/lints/undefined_variable/function_overriding.lua
@@ -1,0 +1,1 @@
+function global.name() end

--- a/selene-lib/tests/lints/undefined_variable/function_overriding.stderr
+++ b/selene-lib/tests/lints/undefined_variable/function_overriding.stderr
@@ -1,0 +1,6 @@
+error[undefined_variable]: `global` is not defined
+  ┌─ function_overriding.lua:1:10
+  │
+1 │ function global.name() end
+  │          ^^^^^^
+

--- a/selene-lib/tests/lints/unscoped_variables/function_overriding.lua
+++ b/selene-lib/tests/lints/unscoped_variables/function_overriding.lua
@@ -1,0 +1,1 @@
+function global.name() end

--- a/selene-lib/tests/lints/unused_variable/function_overriding.lua
+++ b/selene-lib/tests/lints/unused_variable/function_overriding.lua
@@ -1,0 +1,1 @@
+function global.name() end

--- a/selene-lib/tests/lints/unused_variable/function_overriding.std.yml
+++ b/selene-lib/tests/lints/unused_variable/function_overriding.std.yml
@@ -1,0 +1,3 @@
+globals:
+  global:
+    any: true


### PR DESCRIPTION
The following code:

```lua
function global.name() end
```

...would cause 3 separate bugs:

1. `undefined_variable` would not bother checking for `global` (inadequate)
2. `unscoped_variable` would see the write to `global` without a definition, and lint (incorrect)
3. `unused_variable` would tag `global` as unused if `global` was in the standard library (incorrect)

This should help out non-Roblox codebases where code like this isn't uncommon, such as in LOVE.

Fixes #157.