### PR TITLE
Add `--exclude-dir` option

### DIFF
--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -479,6 +479,8 @@ fn start(mut matches: opts::Options) {
 
     let pool = ThreadPool::new(matches.num_threads);
 
+    let exclude_path = &matches.exclude_path.as_ref();
+
     for filename in &matches.files {
         if filename == "-" {
             let checker = Arc::clone(&checker);
@@ -510,6 +512,15 @@ fn start(mut matches: opts::Options) {
                         for entry in glob {
                             match entry {
                                 Ok(path) => {
+                                    match exclude_path {
+                                        Some(exclude) => {
+                                            if path.starts_with(exclude) {
+                                                continue;
+                                            }
+                                        }
+                                        None => {}
+                                    }
+
                                     let checker = Arc::clone(&checker);
 
                                     pool.execute(move || read_file(&checker, &path));

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -479,7 +479,7 @@ fn start(mut matches: opts::Options) {
 
     let pool = ThreadPool::new(matches.num_threads);
 
-    let exclude_path = &matches.exclude_path.as_ref();
+    let exclude_dir = &matches.exclude_dir.as_ref();
 
     for filename in &matches.files {
         if filename == "-" {
@@ -512,7 +512,7 @@ fn start(mut matches: opts::Options) {
                         for entry in glob {
                             match entry {
                                 Ok(path) => {
-                                    match exclude_path {
+                                    match exclude_dir {
                                         Some(exclude) => {
                                             if path.starts_with(exclude) {
                                                 continue;

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -63,7 +63,7 @@ pub struct Options {
     pub command: Option<Command>,
 
     #[structopt(long)]
-    pub exclude_path: Option<String>,
+    pub exclude_dir: Option<String>,
 }
 
 impl Options {

--- a/selene/src/opts.rs
+++ b/selene/src/opts.rs
@@ -61,6 +61,9 @@ pub struct Options {
 
     #[structopt(subcommand)]
     pub command: Option<Command>,
+
+    #[structopt(long)]
+    pub exclude_path: Option<String>,
 }
 
 impl Options {


### PR DESCRIPTION
Implements an `--exclude-dir` option which allows omitting a directory from being linted. Useful for those who use external libraries in their projects.