### PR TITLE
Add exclude option in selene.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.20.0...HEAD)
+## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.21.0...HEAD)
+
+### Added
+- Added exclude option to selene.toml for excluding files from lints
 
 ## [0.21.0](https://github.com/Kampfkarren/selene/releases/tag/0.21.0) - 2022-09-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +371,19 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "hashbrown"
@@ -828,6 +856,7 @@ dependencies = [
  "dirs",
  "full_moon",
  "glob",
+ "globset",
  "lazy_static",
  "num_cpus",
  "profiling",

--- a/docs/src/usage/configuration.md
+++ b/docs/src/usage/configuration.md
@@ -62,3 +62,10 @@ For example, if we had `game.toml` and `engine.toml` standard libraries, we coul
 ```toml
 std = "game+engine"
 ```
+
+### Excluding files from being linted
+It is possible to exclude files from being linted using the exclude option:
+
+```toml
+exclude = ["external/*", "*.spec.lua"]
+```

--- a/selene-lib/src/lib.rs
+++ b/selene-lib/src/lib.rs
@@ -65,6 +65,7 @@ pub struct CheckerConfig<V> {
     pub config: HashMap<String, V>,
     pub rules: HashMap<String, RuleVariation>,
     pub std: String,
+    pub exclude: Vec<String>,
 
     // Not locked behind Roblox feature so that selene.toml for Roblox will
     // run even without it.
@@ -77,6 +78,7 @@ impl<V> Default for CheckerConfig<V> {
             config: HashMap::new(),
             rules: HashMap::new(),
             std: "".to_owned(),
+            exclude: Vec::new(),
             roblox_std_source: RobloxStdSource::default(),
         }
     }

--- a/selene/Cargo.toml
+++ b/selene/Cargo.toml
@@ -20,6 +20,7 @@ color-eyre = "0.6.1"
 dirs = "4.0.0"
 full_moon = "0.15.1"
 glob = "0.3"
+globset = "0.4.9"
 lazy_static = "1.4"
 num_cpus = "1.10"
 profiling = { version = "1.0.6" }

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -471,10 +471,10 @@ fn start(mut matches: opts::Options) {
 
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in &config.exclude {
-        builder.add(match globset::Glob::new(&format!("{}", pattern)) {
+        builder.add(match globset::Glob::new(&pattern) {
             Ok(glob) => glob,
             Err(error) => {
-                error!("Invalid glob pattern: {}", error);
+                error!("Invalid glob pattern: {error}");
                 return;
             }
         });
@@ -532,6 +532,7 @@ fn start(mut matches: opts::Options) {
                                     if exclude_set.is_match(&path) {
                                         continue;
                                     }
+
                                     let checker = Arc::clone(&checker);
 
                                     pool.execute(move || read_file(&checker, &path));

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -471,7 +471,7 @@ fn start(mut matches: opts::Options) {
 
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in &config.exclude {
-        builder.add(match globset::Glob::new(&pattern) {
+        builder.add(match globset::Glob::new(pattern) {
             Ok(glob) => glob,
             Err(error) => {
                 error!("Invalid glob pattern: {error}");


### PR DESCRIPTION
This implements an `exclude` glob option in selene.toml which excludes any files matching with the globs from being linted.