### PR TITLE
Use correct process exit code when encountering error

### DIFF
--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -479,7 +479,7 @@ fn start(mut matches: opts::Options) {
             Ok(glob) => glob,
             Err(error) => {
                 error!("Invalid glob pattern: {error}");
-                return;
+                std::process::exit(1);
             }
         });
     }
@@ -488,7 +488,7 @@ fn start(mut matches: opts::Options) {
         Ok(globset) => globset,
         Err(error) => {
             error!("{error}");
-            return;
+            std::process::exit(1);
         }
     };
 
@@ -526,7 +526,7 @@ fn start(mut matches: opts::Options) {
                             Ok(glob) => glob,
                             Err(error) => {
                                 error!("Invalid glob pattern: {}", error);
-                                return;
+                                std::process::exit(1);
                             }
                         };
 


### PR DESCRIPTION
Uses the `std::proces::exit(1)` method over `return` calls to stop the program (which results in a success exit code incorrectly).

These discrepancies from other parts of the source code was introduced in #425 and #396 ([here](https://github.com/Kampfkarren/selene/pull/396/files#diff-aaa5fc283b5d1c7c8e736156dbc234b8b24909ca32db8c41fef76c9aa79717f4R502-R503)).