### PR TITLE
Add YAML as a valid extension for the settings file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `--allow-warnings` option to have selene pass when only warnings occur.
 - Added the ability to allow specific patterns in the `deprecated` lint.
 - Added exclude option to selene.toml for excluding files from lints
-- Added `testez.yaml` as a supported _Testez_ configuration file.
+- Adds support for `.yaml` extensions to be used for standard libraries alongside `.yml`.
 
 ### Changed
 - Updated internal parser, giving substantial parsing speed increases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `--allow-warnings` option to have selene pass when only warnings occur.
 - Added the ability to allow specific patterns in the `deprecated` lint.
 - Added exclude option to selene.toml for excluding files from lints
+- Added `testez.yaml` as a supported _Testez_ configuration file.
 
 ### Changed
 - Updated internal parser, giving substantial parsing speed increases.

--- a/docs/src/roblox.md
+++ b/docs/src/roblox.md
@@ -24,7 +24,7 @@ Roblox has provided an open source testing utility called [TestEZ](https://roblo
 
 `std = "roblox+testez"`
 
-But first you'll need to create a `testez.yml` or `testez.yaml` file, which you can do so [with this template](https://gist.github.com/Kampfkarren/f2dddc2ebfa4e0662e44b8702e519c2d).
+But first you'll need to create a `testez.yml` file, which you can do so [with this template](https://gist.github.com/Kampfkarren/f2dddc2ebfa4e0662e44b8702e519c2d).
 
 ## Pinned standard library
 

--- a/docs/src/roblox.md
+++ b/docs/src/roblox.md
@@ -24,7 +24,7 @@ Roblox has provided an open source testing utility called [TestEZ](https://roblo
 
 `std = "roblox+testez"`
 
-But first you'll need to create a `testez.yml` file, which you can do so [with this template](https://gist.github.com/Kampfkarren/f2dddc2ebfa4e0662e44b8702e519c2d).
+But first you'll need to create a `testez.yml` or `testez.yaml` file, which you can do so [with this template](https://gist.github.com/Kampfkarren/f2dddc2ebfa4e0662e44b8702e519c2d).
 
 ## Pinned standard library
 

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -449,6 +449,7 @@ fn start(mut matches: opts::Options) {
                     .split('+')
                     .filter(|name| {
                         !PathBuf::from(format!("{name}.yml")).exists()
+                            && !PathBuf::from(format!("{name}.yaml")).exists()
                             && !PathBuf::from(format!("{name}.toml")).exists()
                     })
                     .filter(|name| !cfg!(feature = "roblox") || *name != "roblox")

--- a/selene/src/standard_library.rs
+++ b/selene/src/standard_library.rs
@@ -71,10 +71,11 @@ fn from_name<V>(
 
         library = v1_library.into();
     } else {
-        let yaml_file = directory.join(format!("{standard_library_name}.yml"));
+        let mut yaml_file = directory.join(format!("{standard_library_name}.yml"));
         if !yaml_file.exists() {
             yaml_file = directory.join(format!("{standard_library_name}.yaml"));
         }
+
         if yaml_file.exists() {
             let content = fs::read_to_string(&yaml_file)
                 .with_context(|| format!("failed to read {}", yaml_file.display()))?;

--- a/selene/src/standard_library.rs
+++ b/selene/src/standard_library.rs
@@ -72,6 +72,9 @@ fn from_name<V>(
         library = v1_library.into();
     } else {
         let yaml_file = directory.join(format!("{standard_library_name}.yml"));
+        if !yaml_file.exists() {
+            yaml_file = directory.join(format!("{standard_library_name}.yaml"));
+        }
         if yaml_file.exists() {
             let content = fs::read_to_string(&yaml_file)
                 .with_context(|| format!("failed to read {}", yaml_file.display()))?;


### PR DESCRIPTION
The current PR solves #408 by appending `yaml` as the list of valid extensions for the `std` configuration files.

The current solution **requires to be tested** by the issue creator or a project maintainer.

Also, considering that this is my first contribution to the project, could you kindly set a review on my proceeding @Kampfkarren?

Thank you in advance.