### PR TITLE
Add random linter rule for ensuring concise calls

### DIFF
--- a/selene-lib/default_std/lua51.yml
+++ b/selene-lib/default_std/lua51.yml
@@ -329,9 +329,8 @@ globals:
     must_use: true
   math.random:
     args:
-      - required: false
-        type: number
-      - required: false
+      - type: number
+      - required: math.random should be called with 2 parameters
         type: number
     must_use: true
   math.randomseed:


### PR DESCRIPTION
The current PR solves #393 by ensuring that `Math.random` is used with 2 parameters in the linter.
However, it should be taken into account that `Math.random` could also be used without any parameter and returns a floating point number as it could be seen in [Lua Documentation](http://lua-users.org/wiki/MathLibraryTutorial).

A discussion is set in the cited issue about the topic.