### PR TITLE
Add additional Font constructors to Roblox Standard Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Added `--display-style=json2`, which gives the same outputs as `--display-style=json`, but with an extra `type` field so that it can support more than diagnostics. Extensions should move over to `--display-style=json2` as more becomes available for it, but take care to check for `type`. Currently the only possible value is "Diagnostic".
 - Added `rawlen` to the Luau standard library.
+- Added `Font.fromEnum`, `Font.fromName` and `Font.fromId` to the Roblox Standard Library
 
 ## [0.22.0](https://github.com/Kampfkarren/selene/releases/tag/0.22.0) - 2022-10-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Added `--display-style=json2`, which gives the same outputs as `--display-style=json`, but with an extra `type` field so that it can support more than diagnostics. Extensions should move over to `--display-style=json2` as more becomes available for it, but take care to check for `type`. Currently the only possible value is "Diagnostic".
 - Added `rawlen` to the Luau standard library.
-- Added `Font.fromEnum`, `Font.fromName` and `Font.fromId` to the Roblox Standard Library
+- Added `Font.fromEnum`, `Font.fromName`, and `Font.fromId` to the Roblox standard library.
 
 ## [0.22.0](https://github.com/Kampfkarren/selene/releases/tag/0.22.0) - 2022-10-15
 ### Added

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -262,15 +262,40 @@ globals:
     args:
       - type: "..."
     must_use: true
+  Font.fromEnum:
+    args:
+      - type:
+          display: Font
+    must_use: true
+  Font.fromName:
+    args:
+      - type: string
+      - required: false
+        type:
+          display: FontWeight
+      - required: false
+        type:
+          display: FontStyle
+    must_use: true
+  Font.fromId:
+    args:
+      - type: number
+      - required: false
+        type:
+          display: FontWeight
+      - required: false
+        type:
+          display: FontStyle
+    must_use: true
   Font.new:
     args:
       - type: string
       - required: false
         type:
-          display: "Enum.FontWeight"
+          display: FontWeight
       - required: false
         type:
-          display: "Enum.FontStyle"
+          display: FontStyle
     must_use: true
   FloatCurveKey.new:
     args:


### PR DESCRIPTION
Added the Font.fromEnum, Font.fromName and Font.fromId constructors to the Roblox Standard Library.

Additionally updated the types values of the Font.new constructor to properly reflect the other Enum types.

The constructors can be found on the [Roblox API Documentation Site](https://create.roblox.com/docs/reference/engine/datatypes/Font#summary-constructors)