### PR TITLE
Print linting summary as JSON if display-style is json or json2

### DIFF
--- a/selene/src/json_output.rs
+++ b/selene/src/json_output.rs
@@ -15,9 +15,9 @@ pub enum JsonOutput {
 
 #[derive(Serialize)]
 pub struct JsonSummary {
-    pub(crate) errors: usize,
-    pub(crate) warnings: usize,
-    pub(crate) parse_errors: usize,
+    errors: usize,
+    warnings: usize,
+    parse_errors: usize,
 }
 
 #[derive(Serialize)]
@@ -104,10 +104,8 @@ pub fn log_total_json(
             errors: lint_errors,
             warnings: lint_warnings,
             parse_errors
-        }))
-            .unwrap()
-    )
-        .unwrap();
+        }))?
+    )?;
 
     Ok(())
 }

--- a/selene/src/json_output.rs
+++ b/selene/src/json_output.rs
@@ -1,10 +1,10 @@
-use std::io;
+use std::io::{self, Write};
+
 use codespan_reporting::diagnostic::{
     Diagnostic as CodespanDiagnostic, Label as CodespanLabel, LabelStyle, Severity,
 };
 use serde::Serialize;
 use termcolor::StandardStream;
-use std::io::Write;
 
 #[derive(Serialize)]
 #[serde(tag = "type")]

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -23,8 +23,8 @@ use upgrade_std::upgrade_std;
 
 #[cfg(feature = "roblox")]
 use selene_lib::standard_library::StandardLibrary;
-use crate::json_output::log_total_json;
-use crate::opts::DisplayStyle;
+
+use crate::{json_output::log_total_json, opts::DisplayStyle};
 
 mod json_output;
 mod opts;

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -23,6 +23,8 @@ use upgrade_std::upgrade_std;
 
 #[cfg(feature = "roblox")]
 use selene_lib::standard_library::StandardLibrary;
+use crate::json_output::log_total_json;
+use crate::opts::DisplayStyle;
 
 mod json_output;
 mod opts;
@@ -77,9 +79,26 @@ pub fn error(text: &str) {
 }
 
 fn log_total(parse_errors: usize, lint_errors: usize, lint_warnings: usize) -> io::Result<()> {
-    let mut stdout = StandardStream::stdout(get_color());
+    let lock = OPTIONS.read().unwrap();
+    let opts = lock.as_ref().unwrap();
 
+    let mut stdout = StandardStream::stdout(get_color());
     stdout.reset()?;
+
+    match opts.display_style {
+        Some(DisplayStyle::Json) | Some(DisplayStyle::Json2) => {
+            log_total_json(stdout, parse_errors, lint_errors, lint_warnings)
+        }
+        _ => log_total_text(stdout, parse_errors, lint_errors, lint_warnings),
+    }
+}
+
+fn log_total_text(
+    mut stdout: StandardStream,
+    parse_errors: usize,
+    lint_errors: usize,
+    lint_warnings: usize,
+) -> io::Result<()> {
     writeln!(&mut stdout, "Results:")?;
 
     let mut stat = |number: usize, label: &str| -> io::Result<()> {

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -86,7 +86,7 @@ fn log_total(parse_errors: usize, lint_errors: usize, lint_warnings: usize) -> i
     stdout.reset()?;
 
     match opts.display_style {
-        Some(DisplayStyle::Json) | Some(DisplayStyle::Json2) => {
+        Some(DisplayStyle::Json2) => {
             log_total_json(stdout, parse_errors, lint_errors, lint_warnings)
         }
         _ => log_total_text(stdout, parse_errors, lint_errors, lint_warnings),


### PR DESCRIPTION
When requesting "display-style" to be json(2), optimally the entire output of the application should be JSON, so that it can be easily consumed by another application, without having to filter out non-JSON lines. This PR adds the ability to print the summary as JSON instead of printing it as plain text.

PS: Cool project, thanks for building it 🚀 