### PR TITLE
Add foreachi to 5.1 spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `rawlen` to the Luau standard library.
 - Added `Font.fromEnum`, `Font.fromName`, and `Font.fromId` to the Roblox standard library.
 
+### Fixed
+- Added the missing `table.foreachi` function to Lua5.1 standard library.
+
 ## [0.22.0](https://github.com/Kampfkarren/selene/releases/tag/0.22.0) - 2022-10-15
 ### Added
 - Added `--allow-warnings` option to have selene pass when only warnings occur.

--- a/selene-lib/default_std/lua51.yml
+++ b/selene-lib/default_std/lua51.yml
@@ -582,6 +582,12 @@ globals:
       - type: function
     deprecated:
       message: use a for loop instead.
+  table.foreachi:
+    args:
+      - type: table
+      - type: function
+    deprecated:
+      message: use a for loop instead.
   table.getn:
     args:
       - type: table


### PR DESCRIPTION
`table.foreachi` is still available in 5.1, but deprecated:
[deprecation](https://www.lua.org/manual/5.1/manual.html#7.2)
[function signature](https://www.lua.org/manual/5.0/manual.html#5.4)