### PR TITLE
(Feat) cli subcommands to vscode command palette

### DIFF
--- a/selene-vscode/CHANGELOG.md
+++ b/selene-vscode/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "selene-vscode" extension will be documented in this 
 
 If you want to stay up to date with selene itself, you can find the changelog in [selene's CHANGELOG.md](https://github.com/Kampfkarren/selene/blob/master/CHANGELOG.md).
 
-## [1.2.1]
+## [Unreleased]
 - Added `update-roblox-std` and `generate-roblox-std` subcommands to vscode command palette
 
 ## [1.2.0]

--- a/selene-vscode/CHANGELOG.md
+++ b/selene-vscode/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "selene-vscode" extension will be documented in this 
 
 If you want to stay up to date with selene itself, you can find the changelog in [selene's CHANGELOG.md](https://github.com/Kampfkarren/selene/blob/master/CHANGELOG.md).
 
+## [1.2.1]
+- Added `update-roblox-std` and `generate-roblox-std` subcommands to vscode command palette
+
 ## [1.2.0]
 - Temporary paths, such as Git diff previews, will now use your current workspace folder for configuration.
 - Fixed a bug where the extension would become unusable if it couldn't connect to the internet.

--- a/selene-vscode/package-lock.json
+++ b/selene-vscode/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "selene-vscode",
             "version": "1.2.0",
             "dependencies": {
                 "fs-write-stream-atomic": "^1.0.10",

--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -13,7 +13,9 @@
     ],
     "activationEvents": [
         "onLanguage:lua",
-        "onCommand:selene.reinstall"
+        "onCommand:selene.reinstall",
+        "onCommand:selene.update-roblox-std",
+        "onCommand:selene.generate-roblox-std"
     ],
     "main": "./out/extension.js",
     "scripts": {
@@ -28,6 +30,16 @@
             {
                 "command": "selene.reinstall",
                 "title": "Reinstall Selene",
+                "category": "Selene"
+            },
+            {
+                "command": "selene.update-roblox-std",
+                "title": "update-roblox-std",
+                "category": "Selene"
+            },
+            {
+                "command": "selene.generate-roblox-std",
+                "title": "generate-roblox-std",
                 "category": "Selene"
             }
         ],

--- a/selene-vscode/package.json
+++ b/selene-vscode/package.json
@@ -34,12 +34,12 @@
             },
             {
                 "command": "selene.update-roblox-std",
-                "title": "update-roblox-std",
+                "title": "Update installed Roblox standard library (update-roblox-std)",
                 "category": "Selene"
             },
             {
                 "command": "selene.generate-roblox-std",
-                "title": "generate-roblox-std",
+                "title": "Generate Roblox standard library as roblox.yml (generate-roblox-std)",
                 "category": "Selene"
             }
         ],

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -99,7 +99,7 @@ export async function activate(
                         )
                         return false
                     })
-                vscode.window.showInformationMessage(String(output)?.trim())
+                vscode.window.showInformationMessage(output?.toString() || "")
             },
         ),
         vscode.commands.registerCommand(
@@ -117,7 +117,7 @@ export async function activate(
                         )
                         return false
                     })
-                vscode.window.showInformationMessage(String(output)?.trim())
+                vscode.window.showInformationMessage(output?.toString() || "")
             },
         ),
     )

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -84,37 +84,42 @@ export async function activate(
                 .catch(() => false)
             return trySelene
         }),
-        vscode.commands.registerCommand("selene.update-roblox-std", async () => {
-            const output = (
-                await selene.seleneCommand(
-                    context.globalStorageUri,
-                    "update-roblox-std",
-                    selene.Expectation.Stdout,
-                ).catch((error) => {
-                    vscode.window.showErrorMessage(
-                        `Couldn't update Roblox standard library: \n${error}`,
+        vscode.commands.registerCommand(
+            "selene.update-roblox-std",
+            async () => {
+                const output = await selene
+                    .seleneCommand(
+                        context.globalStorageUri,
+                        "update-roblox-std",
+                        selene.Expectation.Stdout,
                     )
-                    return false
-                }
-                ))
-            vscode.window.showInformationMessage(String(output)?.trim())
-        }),
-        vscode.commands.registerCommand("selene.generate-roblox-std", async () => {
-            const output = (
-                await selene.seleneCommand(
-                    context.globalStorageUri,
-                    "generate-roblox-std",
-                    selene.Expectation.Stdout,
-                ).catch((error) => {
-                    vscode.window.showErrorMessage(
-                        `Couldn't create Roblox standard library: \n${error}`,
+                    .catch((error) => {
+                        vscode.window.showErrorMessage(
+                            `Couldn't update Roblox standard library: \n${error}`,
+                        )
+                        return false
+                    })
+                vscode.window.showInformationMessage(String(output)?.trim())
+            },
+        ),
+        vscode.commands.registerCommand(
+            "selene.generate-roblox-std",
+            async () => {
+                const output = await selene
+                    .seleneCommand(
+                        context.globalStorageUri,
+                        "generate-roblox-std",
+                        selene.Expectation.Stdout,
                     )
-                    return false
-                }
-                ))
-            vscode.window.showInformationMessage(String(output)?.trim())
-        })
-
+                    .catch((error) => {
+                        vscode.window.showErrorMessage(
+                            `Couldn't create Roblox standard library: \n${error}`,
+                        )
+                        return false
+                    })
+                vscode.window.showInformationMessage(String(output)?.trim())
+            },
+        ),
     )
 
     const diagnosticsCollection =

--- a/selene-vscode/src/extension.ts
+++ b/selene-vscode/src/extension.ts
@@ -84,6 +84,37 @@ export async function activate(
                 .catch(() => false)
             return trySelene
         }),
+        vscode.commands.registerCommand("selene.update-roblox-std", async () => {
+            const output = (
+                await selene.seleneCommand(
+                    context.globalStorageUri,
+                    "update-roblox-std",
+                    selene.Expectation.Stdout,
+                ).catch((error) => {
+                    vscode.window.showErrorMessage(
+                        `Couldn't update Roblox standard library: \n${error}`,
+                    )
+                    return false
+                }
+                ))
+            vscode.window.showInformationMessage(String(output)?.trim())
+        }),
+        vscode.commands.registerCommand("selene.generate-roblox-std", async () => {
+            const output = (
+                await selene.seleneCommand(
+                    context.globalStorageUri,
+                    "generate-roblox-std",
+                    selene.Expectation.Stdout,
+                ).catch((error) => {
+                    vscode.window.showErrorMessage(
+                        `Couldn't create Roblox standard library: \n${error}`,
+                    )
+                    return false
+                }
+                ))
+            vscode.window.showInformationMessage(String(output)?.trim())
+        })
+
     )
 
     const diagnosticsCollection =


### PR DESCRIPTION
- Added `update-roblox-std` and `generate-roblox-std` subcommands to vscode command palette

###### didn't add the changes to changelog since extension have different changelog 