### PR TITLE
Allow second argument in `Instance.new`

### DIFF
--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -309,9 +309,12 @@ globals:
     must_use: true
   Instance.new:
     args:
-      - type: string
-    # This is only must_use because we don't allow the second parameter
-    must_use: true
+      - required: true
+        type:
+          display: string
+      - required: false
+        type:
+          display: Instance
   NumberRange.new:
     args:
       - type: number


### PR DESCRIPTION
It is not deprecated and it's quite odd that it's disabled.
Also it's not bad usage. It's only bad usage if properties are set after. If properties are not set after setting the Parent then there is no issue.