### PR TITLE
Fix undefined_variable false negative when defining multiple methods in undefined tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 - `string.pack` and `string.unpack` now have proper function signatures in the Lua 5.3 standard library.
 - Moved `math.log` second argument addition from Lua 5.3 std lib to 5.2 std lib
+- `undefined_variable` now correctly errors when defining multiple methods in undefined tables
 
 ## [0.25.0](https://github.com/Kampfkarren/selene/releases/tag/0.25.0) - 2023-03-12
 ### Added

--- a/selene-lib/src/ast_util/scopes.rs
+++ b/selene-lib/src/ast_util/scopes.rs
@@ -943,7 +943,7 @@ impl Visitor for ScopeVisitor {
         let mut names = name.names().iter();
         let base = names.next().unwrap();
 
-        let is_longer_expression = names.next().is_some();
+        let is_longer_expression = names.next().is_some() || name.method_colon().is_some();
 
         if is_longer_expression {
             self.write_name_with(

--- a/selene-lib/tests/lints/undefined_variable/function_overriding.lua
+++ b/selene-lib/tests/lints/undefined_variable/function_overriding.lua
@@ -1,1 +1,7 @@
 function global.name() end
+
+function a.b() end
+function a.c() end
+
+function d:e() end
+function d:f() end

--- a/selene-lib/tests/lints/undefined_variable/function_overriding.stderr
+++ b/selene-lib/tests/lints/undefined_variable/function_overriding.stderr
@@ -4,3 +4,27 @@ error[undefined_variable]: `global` is not defined
 1 │ function global.name() end
   │          ^^^^^^
 
+error[undefined_variable]: `a` is not defined
+  ┌─ function_overriding.lua:3:10
+  │
+3 │ function a.b() end
+  │          ^
+
+error[undefined_variable]: `a` is not defined
+  ┌─ function_overriding.lua:4:10
+  │
+4 │ function a.c() end
+  │          ^
+
+error[undefined_variable]: `d` is not defined
+  ┌─ function_overriding.lua:6:10
+  │
+6 │ function d:e() end
+  │          ^
+
+error[undefined_variable]: `d` is not defined
+  ┌─ function_overriding.lua:7:10
+  │
+7 │ function d:f() end
+  │          ^
+


### PR DESCRIPTION
Fixes #67 and fixes #516. It looks like `is_longer_expression` only checked for `function a.b()`, but didn't account for method colons like `function a:b()`.