### PR TITLE
Fix definition of os.exit() in Lua 5.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `string.pack` and `string.unpack` now have proper function signatures in the Lua 5.3 standard library.
 - Moved `math.log` second argument addition from Lua 5.3 std lib to 5.2 std lib
 - `undefined_variable` now correctly errors when defining multiple methods in undefined tables
+- Corrected `os.exit` definition in Lua 5.2 standard library
 
 ## [0.25.0](https://github.com/Kampfkarren/selene/releases/tag/0.25.0) - 2023-03-12
 ### Added

--- a/selene-lib/default_std/lua52.yml
+++ b/selene-lib/default_std/lua52.yml
@@ -68,6 +68,12 @@ globals:
       - type: number
       - required: false
         type: number
+  os.exit:
+    args:
+      - required: false
+        type: number
+      - required: false
+        type: bool
   package.config:
     property: read-only
   rawlen:


### PR DESCRIPTION
In Lua 5.2, os.exit() gained an additional boolean argument. This updates the stdlib description file to reflect this, which should also affect Lua 5.3 (and 5.4, but this does not appear to exist at this time).