### PR TITLE
Attempt to find `selene.toml` in parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `ignore_pattern` config to `global_usage`, which will ignore any global variables with names that match the pattern
 - `roblox_incorrect_roact_usage` now checks for incorrect Roact17's `createElement` usage on variables named `React`. For Roact17 only, `key`, `children`, and `ref` are valid properties to Roblox instances.
 
+### Changed
+- If `--config` is not defined, `selene.toml` will now be searched for in the current directory and all parent directories.
+
 ### Fixed
 - `string.pack` and `string.unpack` now have proper function signatures in the Lua 5.3 standard library.
 - Moved `math.log` second argument addition from Lua 5.3 std lib to 5.2 std lib


### PR DESCRIPTION
With this change, if the `--config` flag is not specified, selene will search the current directory and all parent directories for a `selene.toml` file, rather than only looking in the current directory.

This does *not* affect standard library file resolution - it is assumed that the standard library file is in the same directory as the config file.

Closes #526.