### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,21 @@
+---
+- id: selene-system
+  name: selene (system)
+  description: An opinionated Lua code linter
+  entry: selene
+  language: system
+  types: [lua]
+
+- id: selene-docker
+  name: selene (docker)
+  description: An opinionated Lua code linter
+  entry: /selene
+  language: docker
+  types: [lua]
+
+- id: selene-github
+  name: selene (GitHub)
+  description: An opinionated Lua code linter
+  entry: selene
+  language: python
+  types: [lua]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `Path2DControlPoint.new` to the Roblox standard library
 - [Adds `lua_versions` to standard library definitions](https://kampfkarren.github.io/selene/usage/std.html#lua_versions). Specifying this will only allow the syntax used by those languages. The default standard libraries now specify these, meaning that invalid syntax for that language will no longer be supported.
 - Added missing third parameter to `PathWaypoint.new` in the Roblox standard library
+- Added support for selene as a `pre-commit` hook
 
 ### Changed
 - Upgrades to [full-moon 1.0.0](https://github.com/Kampfkarren/full-moon/blob/main/CHANGELOG.md#100---2024-10-08), which should provide faster parse speeds, support for multiple parsing errors at the same time, and support for some new Luau syntax.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ FROM bash AS selene-light
 COPY --from=selene-light-builder /usr/local/cargo/bin/selene /
 CMD ["/selene"]
 
-FROM bash AS selene-musl
-COPY --from=selene-musl-builder /usr/local/cargo/bin/selene /
-CMD ["/selene"]
-
 FROM bash AS selene-light-musl
 COPY --from=selene-light-musl-builder /usr/local/cargo/bin/selene /
+CMD ["/selene"]
+
+FROM bash AS selene-musl
+COPY --from=selene-musl-builder /usr/local/cargo/bin/selene /
 CMD ["/selene"]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Configuration](./usage/configuration.md)
   - [Filtering](./usage/filtering.md)
   - [Standard Library Format](./usage/std.md)
+  - [Git hooks (pre-commit)](./usage/git-hooks-pre-commit.md)
 - [Roblox Guide](./roblox.md)
 - [Contributing](./contributing.md)
 - [Lints](./lints/index.md)

--- a/docs/src/usage/git-hooks-pre-commit.md
+++ b/docs/src/usage/git-hooks-pre-commit.md
@@ -1,0 +1,35 @@
+# Pre-commit
+
+`pre-commit` allows integration of `selene` into your Git workflow using git hooks. After [installing pre-commit](https://pre-commit.com/#install), add one of the following configurations to your `.pre-commit-config.yaml` file:
+
+* Use the `selene` binary present on the system path (Should be pre-installed):
+
+```yaml
+repos:
+  - repo: https://github.com/Kampfkarren/selene
+    rev: ''
+    hooks:
+      - id: selene-system
+```
+
+* Use `selene` through GitHub releases:
+
+```yaml
+repos:
+  - repo: https://github.com/Kampfkarren/selene
+    rev: ''
+    hooks:
+      - id: selene-github
+```
+
+* Use the `selene` binary present in the `selene` docker image (Since this uses docker, it might take some time to bootstrap and is slower than the other two options):
+
+```yaml
+repos:
+  - repo: https://github.com/Kampfkarren/selene
+    rev: ''
+    hooks:
+      - id: selene-docker
+```
+
+You may see a `warning` being generated when pre-commit runs. To resolve that, set the `rev` key to any selene tag or commit, for e.g. `rev: '0.26.2'`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["release-gitter[builder]"]
+build-backend = "pseudo_builder"
+
+[tool.release-gitter]
+git-url = "https://github.com/Kampfkarren/selene"
+extract-files = ["selene"]
+format = "selene-{version}-{system}.zip"
+exec = "chmod +x selene"


### PR DESCRIPTION
Fixes #539

Rust-based pre-commit does not work because pre-commit hardcodes the `--path` to `.` which leads to build failure and errors with `found a virtual manifest at <path>/Cargo.toml` instead of a package manifest. Pre-commit maintainer disagrees with making this configurable so it is not possible to add a `rust` based hook: https://github.com/pre-commit/pre-commit/issues/2931