### PR TITLE
Add buffer library to Luau standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `no-exclude` cli flag to disable excludes.
 - When given in standard library format, additional information now shows up in `incorrect_standard_library_use` missing required parameter errors.
 - Added new [`mixed_table` lint](https://kampfkarren.github.io/selene/lints/mixed_table.html), which will warn against mixed tables.
+- Added `buffer` library to Luau standard library
 
 ### Fixed
 - `string.pack` and `string.unpack` now have proper function signatures in the Lua 5.3 standard library.

--- a/selene-lib/default_std/luau.yml
+++ b/selene-lib/default_std/luau.yml
@@ -73,11 +73,11 @@ globals:
       - type: number
     must_use: true
   buffer.create:
-    arg:
+    args:
       - type: number
     must_use: true
   buffer.copy:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
@@ -88,7 +88,7 @@ globals:
       - required: false
         type: number
   buffer.fill:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
@@ -96,124 +96,124 @@ globals:
       - required: false
         type: number
   buffer.fromstring:
-    arg:
+    args:
       - type: string
     must_use: true
   buffer.len:
-    arg:
+    args:
       - type:
           display: buffer
     must_use: true
   buffer.readi8:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readi16:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readi32:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readf32:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readf64:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readu8:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readu16:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readu32:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
     must_use: true
   buffer.readstring:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
     must_use: true
   buffer.tostring:
-    arg:
+    args:
       - type:
           display: buffer
     must_use: true
   buffer.writei8:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writei16:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writei32:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writef32:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writef64:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writeu8:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writeu16:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writeu32:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number
       - type: number
   buffer.writestring:
-    arg:
+    args:
       - type:
           display: buffer
       - type: number

--- a/selene-lib/default_std/luau.yml
+++ b/selene-lib/default_std/luau.yml
@@ -72,10 +72,6 @@ globals:
       - type: number
       - type: number
     must_use: true
-  buffer.create:
-    args:
-      - type: number
-    must_use: true
   buffer.copy:
     args:
       - type:
@@ -87,6 +83,10 @@ globals:
         type: number
       - required: false
         type: number
+  buffer.create:
+    args:
+      - type: number
+    must_use: true
   buffer.fill:
     args:
       - type:
@@ -103,6 +103,18 @@ globals:
     args:
       - type:
           display: buffer
+    must_use: true
+  buffer.readf32:
+    args:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readf64:
+    args:
+      - type:
+          display: buffer
+      - type: number
     must_use: true
   buffer.readi8:
     args:
@@ -122,16 +134,11 @@ globals:
           display: buffer
       - type: number
     must_use: true
-  buffer.readf32:
+  buffer.readstring:
     args:
       - type:
           display: buffer
       - type: number
-    must_use: true
-  buffer.readf64:
-    args:
-      - type:
-          display: buffer
       - type: number
     must_use: true
   buffer.readu8:
@@ -152,18 +159,23 @@ globals:
           display: buffer
       - type: number
     must_use: true
-  buffer.readstring:
-    args:
-      - type:
-          display: buffer
-      - type: number
-      - type: number
-    must_use: true
   buffer.tostring:
     args:
       - type:
           display: buffer
     must_use: true
+  buffer.writef32:
+    args:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writef64:
+    args:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
   buffer.writei8:
     args:
       - type:
@@ -182,18 +194,14 @@ globals:
           display: buffer
       - type: number
       - type: number
-  buffer.writef32:
+  buffer.writestring:
     args:
       - type:
           display: buffer
       - type: number
-      - type: number
-  buffer.writef64:
-    args:
-      - type:
-          display: buffer
-      - type: number
-      - type: number
+      - type: string
+      - required: false
+        type: number
   buffer.writeu8:
     args:
       - type:
@@ -212,14 +220,6 @@ globals:
           display: buffer
       - type: number
       - type: number
-  buffer.writestring:
-    args:
-      - type:
-          display: buffer
-      - type: number
-      - type: string
-      - required: false
-        type: number
   collectgarbage:
     args:
       - type:

--- a/selene-lib/default_std/luau.yml
+++ b/selene-lib/default_std/luau.yml
@@ -72,6 +72,154 @@ globals:
       - type: number
       - type: number
     must_use: true
+  buffer.create:
+    arg:
+      - type: number
+    must_use: true
+  buffer.copy:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type:
+          display: buffer
+      - required: false
+        type: number
+      - required: false
+        type: number
+  buffer.fill:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+      - required: false
+        type: number
+  buffer.fromstring:
+    arg:
+      - type: string
+    must_use: true
+  buffer.len:
+    arg:
+      - type:
+          display: buffer
+    must_use: true
+  buffer.readi8:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readi16:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readi32:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readf32:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readf64:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readu8:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readu16:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readu32:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+    must_use: true
+  buffer.readstring:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+    must_use: true
+  buffer.tostring:
+    arg:
+      - type:
+          display: buffer
+    must_use: true
+  buffer.writei8:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writei16:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writei32:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writef32:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writef64:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writeu8:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writeu16:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writeu32:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: number
+  buffer.writestring:
+    arg:
+      - type:
+          display: buffer
+      - type: number
+      - type: string
+      - required: false
+        type: number
   collectgarbage:
     args:
       - type:


### PR DESCRIPTION
This adds the buffer library to the Luau standard library.

I tried my best to sort them in alphabetical order but it was done by hand, so there's a chance I made a mistake.