### PR TITLE
Add bit32.byteswap to Luau standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `no-exclude` cli flag to disable excludes.
 - When given in standard library format, additional information now shows up in `incorrect_standard_library_use` missing required parameter errors.
 - Added new [`mixed_table` lint](https://kampfkarren.github.io/selene/lints/mixed_table.html), which will warn against mixed tables.
+- Added `bit32.byteswap` to Luau standard library
 
 ### Fixed
 - `string.pack` and `string.unpack` now have proper function signatures in the Lua 5.3 standard library.

--- a/selene-lib/default_std/luau.yml
+++ b/selene-lib/default_std/luau.yml
@@ -29,6 +29,10 @@ globals:
     args:
       - type: "..."
     must_use: true
+  bit32.byteswap:
+    args:
+      - type: number
+    must_use: true
   bit32.countlz:
     args:
       - type: number


### PR DESCRIPTION
Adds bit32.byteswap to the Luau standard library.