### PR TITLE
Add `CFrame.lookAlong` to the Roblox standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.26.1...HEAD)
+### Added
+- Added `CFrame.lookAlong` to the Roblox standard library
 
 ## [0.26.1](https://github.com/Kampfkarren/selene/releases/tag/0.26.1) - 2023-11-11
 ### Fixed

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -117,10 +117,6 @@ globals:
       - type:
           display: Vector3
     must_use: true
-<<<<<<< HEAD
-=======
-
->>>>>>> 68a6451ceaf1ec65dccede34473fae71a77b744a
   CFrame.lookAt:
     args:
       - type:

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -117,7 +117,6 @@ globals:
       - type:
           display: Vector3
     must_use: true
-
   CFrame.lookAt:
     args:
       - type:

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -109,13 +109,13 @@ globals:
     property: read-only
   CFrame.lookAlong:
     args:
-    - type:
-        display: Vector3
-    - type:
-        display: Vector3
-    - required: false
-      type:
-        display: Vector3
+      - type:
+          display: Vector3
+      - type:
+          display: Vector3
+      - required: false
+        type:
+          display: Vector3
     must_use: true
   CFrame.lookAt:
     args:

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -107,6 +107,17 @@ globals:
     must_use: true
   CFrame.identity:
     property: read-only
+  CFrame.lookAlong:
+    args:
+      - type:
+          display: Vector3
+      - type:
+          display: Vector3
+      - required: false
+      - type:
+          display: Vector3
+    must_use: true
+
   CFrame.lookAt:
     args:
       - type:

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -109,13 +109,13 @@ globals:
     property: read-only
   CFrame.lookAlong:
     args:
-      - type:
-          display: Vector3
-      - type:
-          display: Vector3
-      - required: false
-      - type:
-          display: Vector3
+    - type:
+        display: Vector3
+    - type:
+        display: Vector3
+    - required: false
+      type:
+        display: Vector3
     must_use: true
   CFrame.lookAt:
     args:


### PR DESCRIPTION
Closes: #576

Adds `CFrame.lookAlong` to the Roblox standard library.