### PR TITLE
Add `must_use` to std docs

### DIFF
--- a/docs/src/usage/std.md
+++ b/docs/src/usage/std.md
@@ -67,6 +67,17 @@ This field is used for allowing smarter introspection of how the argument given 
 - "read" - This argument is only read from. Currently unused.
 - "write" - This argument is only written to. Used by `unused_variable` to assist in detecting a variable only being written to, even if passed into a function.
 
+Example:
+```yml
+ table.insert:
+  args:
+    - type: table
+      observes: write # This way, `table.insert(x, 1)` doesn't count as a read to `x`
+    - type: any
+    - required: false
+      type: any
+```
+
 #### "must_use"
 This field is used for checking if the return value of a function is used.
 
@@ -78,10 +89,10 @@ Example:
 table.find:
   args:
     - type: table
-      observes: read  # The table is only read from
-      required: true  # The table to index is a required argument
+      observes: read
+      required: true
     - type: any
-      required: true  # The value to find is a required argument
+      required: true
   must_use: true  # The return value of this function must be used
 ```
 

--- a/docs/src/usage/std.md
+++ b/docs/src/usage/std.md
@@ -67,15 +67,22 @@ This field is used for allowing smarter introspection of how the argument given 
 - "read" - This argument is only read from. Currently unused.
 - "write" - This argument is only written to. Used by `unused_variable` to assist in detecting a variable only being written to, even if passed into a function.
 
+#### "must_use"
+This field is used for checking if the return value of a function is used.
+
+- `true` - The default. The return value of this function must be used.
+- `false` - The return value of this function does not need to be used.
+
 Example:
 ```yml
- table.insert:
+table.find:
   args:
     - type: table
-      observes: write # This way, `table.insert(x, 1)` doesn't count as a read to `x`
+      observes: read  # The table is only read from
+      required: true  # The table to index is a required argument
     - type: any
-    - required: false
-      type: any
+      required: true  # The value to find is a required argument
+  must_use: true  # The return value of this function must be used
 ```
 
 #### Argument types

--- a/docs/src/usage/std.md
+++ b/docs/src/usage/std.md
@@ -70,8 +70,8 @@ This field is used for allowing smarter introspection of how the argument given 
 #### "must_use"
 This field is used for checking if the return value of a function is used.
 
-- `true` - The default. The return value of this function must be used.
-- `false` - The return value of this function does not need to be used.
+- `true` - The return value of this function must be used.
+- `false` - The default. The return value of this function does not need to be used.
 
 Example:
 ```yml

--- a/docs/src/usage/std.md
+++ b/docs/src/usage/std.md
@@ -81,8 +81,8 @@ Example:
 #### "must_use"
 This field is used for checking if the return value of a function is used.
 
-- `true` - The return value of this function must be used.
 - `false` - The default. The return value of this function does not need to be used.
+- `true` - The return value of this function must be used.
 
 Example:
 ```yml

--- a/docs/src/usage/std.md
+++ b/docs/src/usage/std.md
@@ -86,14 +86,10 @@ This field is used for checking if the return value of a function is used.
 
 Example:
 ```yml
-table.find:
-  args:
-    - type: table
-      observes: read
-      required: true
-    - type: any
-      required: true
-  must_use: true  # The return value of this function must be used
+  tostring:
+    args:
+      - type: any
+    must_use: true
 ```
 
 #### Argument types


### PR DESCRIPTION
Closes: #407 

Adds `must_use` functionality and documentation for std docs.