### PR TITLE
✨feat: `.selene.toml` and `selene.toml` are now detected by order of priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.26.1...HEAD)
 ### Added
 - Added `CFrame.lookAlong` to the Roblox standard library
+- Added `.selene.toml` as possible config file, with priority over `selene.toml`.
 
 ### Changed
 - Updated the warning message for the `mixed_table` lint to include why mixed tables should be avoided

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -16,7 +16,7 @@ FLAGS:
 
 OPTIONS:
         --color <color>                     [default: auto]  [possible values: Always, Auto, Never]
-        --config <config>                  A toml file to configure the behavior of selene [default: selene.toml]
+        --config <config>                  A toml file to configure the behavior of selene [default: .selene.toml]
         --display-style <display-style>    Sets the display method [possible values: Json, Json2, Rich, Quiet]
         --num-threads <num-threads>        Number of threads to run on, default to the numbers of logical cores on your
                                            system [default: your system's cores]

--- a/docs/src/lints/high_cyclomatic_complexity.md
+++ b/docs/src/lints/high_cyclomatic_complexity.md
@@ -29,7 +29,7 @@ end
 
 ## Remarks
 
-This lint is off by default. In order to enable it, add this to your selene.toml:
+This lint is off by default. In order to enable it, add this to your .selene.toml:
 
 ```toml
 [lints]

--- a/docs/src/roblox.md
+++ b/docs/src/roblox.md
@@ -6,13 +6,13 @@ If you try to run selene on a Roblox codebase, you'll get a bunch of errors sayi
 
 ## Installation
 
-Thankfully, this process is very simple. All you need to do is edit your `selene.toml` (or create one) and add the following:
+Thankfully, this process is very simple. All you need to do is edit your `.selene.toml` (or create one) and add the following:
 
 ```toml
 std = "roblox"
 ```
 
-The next time you run selene, or if you use the Visual Studio Code extension and start typing Lua code, a Roblox standard library will be automatically generated and used. This is an automatic process that occurs whenever you don't have a cached standard library file and your `selene.toml` has `std = "roblox"`.
+The next time you run selene, or if you use the Visual Studio Code extension and start typing Lua code, a Roblox standard library will be automatically generated and used. This is an automatic process that occurs whenever you don't have a cached standard library file and your `.selene.toml` has `std = "roblox"`.
 
 ## Updating definitions
 
@@ -32,7 +32,7 @@ There may be cases where you would rather not have selene automatically update t
 
 selene supports "pinning" the standard library to a specific version.
 
-Add the following to your `selene.toml` configuration:
+Add the following to your `.selene.toml` configuration:
 ```toml
 # `floating` by default, meaning it is stored in a cache folder on your system
 roblox-std-source = "pinned"

--- a/docs/src/usage/configuration.md
+++ b/docs/src/usage/configuration.md
@@ -1,10 +1,10 @@
 # Configuration
 selene is meant to be easily configurable. You can specify configurations for the entire project as well as for individual lints.
 
-Configuration files are placed in the directory you are running selene in and are named **selene.toml**. As the name suggests, the configurations use the [Tom's Obvious, Minimal Language (TOML)](https://github.com/toml-lang/toml) format. It is recommended you quickly brush up on the syntax, though it is very easy.
+Configuration files are placed in the directory you are running selene in and are named **.selene.toml** (or **selene.toml**) . As the name suggests, the configurations use the [Tom's Obvious, Minimal Language (TOML)](https://github.com/toml-lang/toml) format. It is recommended you quickly brush up on the syntax, though it is very easy.
 
 ## Changing the severity of lints
-You can change the severity of lints by entering the following into selene.toml:
+You can change the severity of lints by entering the following into .selene.toml:
 
 ```toml
 [lints]
@@ -22,7 +22,7 @@ Where "severity" is one of the following:
 Note that "deny" and "warn" are effectively the same, only warn will give orange text while error gives red text, and they both have different counters.
 
 ## Configuring specific lints
-You can configure specific lints by entering the following into selene.toml:
+You can configure specific lints by entering the following into .selene.toml:
 
 ```toml
 [config]
@@ -47,7 +47,7 @@ By default, selene uses Lua 5.1, though if we wanted to use the Lua 5.2 standard
 std = "lua52"
 ```
 
-...at the top of selene.toml. You can learn more about the standard library format on the [standard library guide](./std.md). The standard library given can either be one of the builtin ones (currently only `lua51` and `lua52`) or the filename of a standard library file in this format. For example, if we had a file named `special.toml`, we would write:
+...at the top of .selene.toml. You can learn more about the standard library format on the [standard library guide](./std.md). The standard library given can either be one of the builtin ones (currently only `lua51` and `lua52`) or the filename of a standard library file in this format. For example, if we had a file named `special.toml`, we would write:
 
 ```toml
 std = "special"

--- a/docs/src/usage/filtering.md
+++ b/docs/src/usage/filtering.md
@@ -27,7 +27,7 @@ However, perhaps we as the programmer have some reason for leaving this unused (
 local something = 1
 ```
 
-This also works with settings other than `allow`--you can `warn` or `deny` lints in the same fashion. For example, you can have a project with the following `selene.toml` [configuration](./configuration.md):
+This also works with settings other than `allow`--you can `warn` or `deny` lints in the same fashion. For example, you can have a project with the following `.selene.toml` [configuration](./configuration.md):
 
 ```toml
 [lints]

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -412,7 +412,7 @@ fn start(mut options: opts::Options) {
 
                 (config_contents, Path::new("-"))
             } else {
-                let config_paths_to_check = [Path::new("selene.toml"), Path::new(".selene.toml")];
+                let config_paths_to_check = [Path::new(".selene.toml"), Path::new("selene.toml")];
                 let mut config_contents = String::new();
                 let mut config_path = Path::new("");
                 let mut config_not_found = true;
@@ -541,8 +541,8 @@ fn start(mut options: opts::Options) {
                         .ok()
                 };
 
-                let config = read_config_file("selene.toml")
-                    .or_else(|| read_config_file(".selene.toml"))
+                let config = read_config_file(".selene.toml")
+                    .or_else(|| read_config_file("selene.toml"))
                     .unwrap_or_else(|| CheckerConfig::default());
 
                 (config, None)

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -396,6 +396,7 @@ fn read_config_file(file: &str) -> Option<CheckerConfig<toml::value::Value>> {
     toml::from_str(&config_contents)
         .map_err(|error| {
             error!("Error parsing config file {file}: {error}");
+            std::process::exit(1);
         })
         .ok()
 }

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -391,6 +391,15 @@ fn read_file(checker: &Checker<toml::value::Value>, filename: &Path) {
     );
 }
 
+fn read_config_file(file: &str) -> Option<CheckerConfig<toml::value::Value>> {
+    let config_contents = fs::read_to_string(file).ok()?;
+    toml::from_str(&config_contents)
+        .map_err(|error| {
+            error!("Error parsing config file {}: {}", file, error);
+        })
+        .ok()
+}
+
 fn start(mut options: opts::Options) {
     *OPTIONS.write().unwrap() = Some(options.clone());
 
@@ -531,15 +540,6 @@ fn start(mut options: opts::Options) {
             }
 
             None => {
-                let read_config_file = |file: &str| -> Option<CheckerConfig<toml::value::Value>> {
-                    let config_contents = fs::read_to_string(file).ok()?;
-                    toml::from_str(&config_contents)
-                        .map_err(|error| {
-                            error!("Error parsing config file {}: {}", file, error);
-                        })
-                        .ok()
-                };
-
                 let config = read_config_file(".selene.toml")
                     .or_else(|| read_config_file("selene.toml"))
                     .unwrap_or_else(|| CheckerConfig::default());

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -535,8 +535,7 @@ fn start(mut options: opts::Options) {
                     let config_contents = fs::read_to_string(file).ok()?;
                     toml::from_str(&config_contents)
                         .map_err(|error| {
-                            eprintln!("Error parsing config file {}: {}", file, error);
-                            error
+                            error!("Error parsing config file {}: {}", file, error);
                         })
                         .ok()
                 };

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -428,20 +428,18 @@ fn start(mut options: opts::Options) {
                 let mut config_not_found = true;
 
                 for path in &config_paths_to_check {
-                    match fs::read_to_string(path) {
-                        Ok(contents) => {
+                    if path.exists() {
+                        if let Ok(contents) = fs::read_to_string(path) {
                             config_contents = contents;
                             config_path = path;
                             config_not_found = false;
                             break;
                         }
-                        Err(error) => {
-                            error!("Error reading config file: {error}");
-                        }
                     }
                 }
 
                 if config_not_found {
+                    error!("Error reading config file");
                     std::process::exit(1);
                 }
 

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -395,7 +395,7 @@ fn read_config_file(file: &str) -> Option<CheckerConfig<toml::value::Value>> {
     let config_contents = fs::read_to_string(file).ok()?;
     toml::from_str(&config_contents)
         .map_err(|error| {
-            error!("Error parsing config file {}: {}", file, error);
+            error!("Error parsing config file {file}: {error}");
         })
         .ok()
 }

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -412,7 +412,7 @@ fn read_config_file() -> Option<(String, Option<PathBuf>)> {
     Some((config_contents, config_path))
 }
 
-/// Read the config file and return it as Option<(String, &'static Path)>.
+/// Read the config file and return it as `Option<(String, &'static Path)>`.
 fn parse_config_file_as_string() -> Option<(String, &'static Path)> {
     if let Some((config_contents, config_path)) = read_config_file() {
         if let Some(path) = config_path {
@@ -425,7 +425,7 @@ fn parse_config_file_as_string() -> Option<(String, &'static Path)> {
     None
 }
 
-/// Read the config file and return it as CheckerConfig<toml::Value>, Option<PathBuf>.
+/// Read the config file and return it as `CheckerConfig<toml::Value>, Option<PathBuf>`.
 fn parse_config_file_as_checkerconfig() -> Option<(CheckerConfig<toml::Value>, Option<PathBuf>)> {
     if let Some((config_contents, config_path)) = read_config_file() {
         match toml::from_str(&config_contents) {

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -391,7 +391,7 @@ fn read_file(checker: &Checker<toml::value::Value>, filename: &Path) {
     );
 }
 
-/// It reads a config file. It returns content and path. None if not found or empty.
+/// Reads a config file and return content and path. None if not found or empty.
 fn read_config_file() -> Option<(String, Option<PathBuf>)> {
     let config_paths_to_check = [".selene.toml", "selene.toml"];
     let mut config_contents = String::new();

--- a/selene/src/main.rs
+++ b/selene/src/main.rs
@@ -572,7 +572,7 @@ fn start(mut options: opts::Options) {
 
             None => {
                 let (config, _) = match read_config_file() {
-                    Some((config, config_path)) => (config, config_path),
+                    Some(config) => config,
                     None => (CheckerConfig::default(), None),
                 };
 


### PR DESCRIPTION
This PR:
* add 20 lines of code, but it keep all the original checkings.
* I've tried it to look as similar to the original code as possible. 
* It should be obvious enough.

The feature has been tested on neovim + none-ls with:
* No file.
* .selene.toml
* selene.toml
* .selene.toml + wrong syntax
* selene.toml + wrong syntax

Example of bad syntax
![screenshot_2024-03-10_04-17-20_778230898](https://github.com/Kampfkarren/selene/assets/3357792/d2f2771d-e7c2-47fa-90fb-22a8afb7a69b)

Example of file detected OK
![screenshot_2024-03-10_04-18-01_912823820](https://github.com/Kampfkarren/selene/assets/3357792/c23aa856-d778-474d-90d6-7e6dcb4a4352)

Example of no config file
![screenshot_2024-03-10_04-19-59_927521326](https://github.com/Kampfkarren/selene/assets/3357792/2df7674f-b8bb-4262-932f-fbe4090086f3)