### PR TITLE
add aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,18 @@ jobs:
       with:
         name: selene-linux
         path: ./target/release/selene
+    - name: Build arm64 (Default features)
+      uses: actions-rs/cargo@v1
+      with:
+        working-directory: selene
+        use-cross: true
+        command: build
+        args: --locked --release --target aarch64-unknown-linux-gnu
+    - name: Upload selene arm64
+      uses: actions/upload-artifact@v1
+      with:
+        name: selene-linux-aarch64
+        path: ./target/aarch64-unknown-linux-gnu/release/selene
   build_linux_light:
     runs-on: ubuntu-latest
     steps:
@@ -91,6 +103,18 @@ jobs:
       with:
         name: selene-light-linux
         path: ./target/release/selene
+    - name: Build arm64 (Lightweight)
+      uses: actions-rs/cargo@v1
+      with:
+        working-directory: selene
+        use-cross: true
+        command: build
+        args: --locked --release --verbose --no-default-features --target aarch64-unknown-linux-gnu
+    - name: Upload selene-light arm64
+      uses: actions/upload-artifact@v1
+      with:
+        name: selene-light-linux-aarch64
+        path: ./target/aarch64-unknown-linux-gnu/release/selene
   release:
     runs-on: ubuntu-latest
     needs: ['build_windows_light', 'build_windows', 'build_mac', 'build_mac_light', 'build_linux', 'build_linux_light']


### PR DESCRIPTION
Hi,

In asahi linux (aarch64), selene is not available in neovim because mason can not download an artifact for it (there is no aarch64 linux on github releases). To fix this, I added a cross compilation step to generate and upload an aarch64 linux binary.

I tested this in my fork, and it correctly generates aarch64 binaries.

Please let me know if you like something changed!