### PR TITLE
add Path2DControlPoint.new to roblox_base.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.27.1...HEAD)
+### Added
+- Added `Path2DControlPoint.new` to the Roblox standard library
 
 ## [0.27.1](https://github.com/Kampfkarren/selene/releases/tag/0.27.1) - 2024-04-28
 ### Fixed

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -349,15 +349,6 @@ globals:
   OverlapParams.new:
     args: []
     must_use: true
-  PathWaypoint.new:
-    args:
-      - required: false
-        type:
-          display: Vector3
-      - required: false
-        type:
-          display: PathWaypointAction
-    must_use: true
   Path2DControlPoint.new:
     args:
       - required: false
@@ -369,6 +360,15 @@ globals:
       - required: false
         type:
           display: UDim2
+    must_use: true
+  PathWaypoint.new:
+    args:
+      - required: false
+        type:
+          display: Vector3
+      - required: false
+        type:
+          display: PathWaypointAction
     must_use: true
   PhysicalProperties.new:
     args:

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -358,6 +358,18 @@ globals:
         type:
           display: PathWaypointAction
     must_use: true
+  Path2DControlPoint.new:
+    args:
+      - required: false
+        type:
+          display: UDim2
+      - required: false
+        type:
+          display: UDim2
+      - required: false
+        type:
+          display: UDim2
+    must_use: true
   PhysicalProperties.new:
     args:
       - type: any


### PR DESCRIPTION
this lint works fine for the majority. besides this bellow, it'll require all 3 args if the second one is present 
Path2DControlPoint.new(UDim2.new(), UDim2.new()) -- RUNTIME ERROR
any way to lint for that