### PR TITLE
Add `Content.none` to Roblox standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.28.0...HEAD)
 - Added `Instance.fromExisting` to the Roblox standard library
 - Added new [`roblox_manual_fromscale_or_fromoffset` lint](https://kampfkarren.github.io/selene/lints/roblox_manual_fromscale_or_fromoffset.html), which will warn when the arguments could be simplified to `UDim2.fromScale` or `UDim2.fromOffset`.
+- Added `Content.none` to the Roblox standard library
 
 ## [0.28.0](https://github.com/Kampfkarren/selene/releases/0.28.0) - 2025-01-09
 ### Added

--- a/selene-lib/default_std/roblox_base.yml
+++ b/selene-lib/default_std/roblox_base.yml
@@ -692,6 +692,8 @@ globals:
     args:
       - required: true
         type: number
+  Content.none:
+    property: read-only
 structs:
   EnumItem:
     Name:


### PR DESCRIPTION
`Content` has a constant `none`. It's documented [here](https://create.roblox.com/docs/reference/engine/datatypes/Content#none).