### PR TITLE
Add math.lerp to list of Luau math lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added new [`roblox_manual_fromscale_or_fromoffset` lint](https://kampfkarren.github.io/selene/lints/roblox_manual_fromscale_or_fromoffset.html), which will warn when the arguments could be simplified to `UDim2.fromScale` or `UDim2.fromOffset`.
 - Added `Content.none` to the Roblox standard library
 - Added `CFrame.fromRotationBetweenVectors` to the Roblox standard library
+- Added `math.lerp` to the Luau standard library
 
 ## [0.28.0](https://github.com/Kampfkarren/selene/releases/0.28.0) - 2025-01-09
 ### Added

--- a/selene-lib/default_std/luau.yml
+++ b/selene-lib/default_std/luau.yml
@@ -294,6 +294,12 @@ globals:
       - type: number
       - type: number
     must_use: true
+  math.lerp:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    must_use: true
   math.log:
     args:
       - type: number
@@ -322,12 +328,6 @@ globals:
     must_use: true
   math.sign:
     args:
-      - type: number
-    must_use: true
-  math.lerp:
-    args:
-      - type: number
-      - type: number
       - type: number
     must_use: true
   module:

--- a/selene-lib/default_std/luau.yml
+++ b/selene-lib/default_std/luau.yml
@@ -324,6 +324,12 @@ globals:
     args:
       - type: number
     must_use: true
+  math.lerp:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    must_use: true
   module:
     removed: true
   os.execute:
@@ -470,7 +476,7 @@ globals:
           display: vector
       - required: false
         type:
-            display: vector
+          display: vector
     must_use: true
   vector.ceil:
     args:


### PR DESCRIPTION
Adds [math.lerp](https://rfcs.luau.org/function-math-lerp.html) to the base Luau lints. Implementation PR: https://github.com/luau-lang/luau/pull/1608 which demonstrates that all 3 number arguments are required.

Manual testing was performed to ensure that the new lint fires whenever `math.lerp` is used and it is missing an argument.
<details>
<summary>Diff of test</summary>

```diff
diff --git a/selene-lib/src/lints/standard_library.rs b/selene-lib/src/lints/standard_library.rs
index 703f278..5bc418c 100644
--- a/selene-lib/src/lints/standard_library.rs
+++ b/selene-lib/src/lints/standard_library.rs
@@ -795,6 +795,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_luau() {
+        test_lint_config(
+            StandardLibraryLint::new(()).unwrap(),
+            "standard_library",
+            "luau",
+            TestUtilConfig {
+                standard_library: StandardLibrary::from_name("luau").unwrap(),
+                ..TestUtilConfig::default()
+            },
+        );
+    }
+
     #[test]
     fn test_math_on_types() {
         test_lint(
diff --git a/selene-lib/tests/lints/standard_library/luau.lua b/selene-lib/tests/lints/standard_library/luau.lua
new file mode 100644
index 0000000..5824636
--- /dev/null
+++ b/selene-lib/tests/lints/standard_library/luau.lua
@@ -0,0 +1,2 @@
+-- math
+math.lerp(0, 5, 0.5)
diff --git a/selene-lib/tests/lints/standard_library/luau.stderr b/selene-lib/tests/lints/standard_library/luau.stderr
new file mode 100644
index 0000000..e69de29
```

which results in all tests passing.
</details>