### PR TITLE
fix: extend() method now merges lua_versions instead of replacing

### DIFF
--- a/selene-lib/src/standard_library/mod.rs
+++ b/selene-lib/src/standard_library/mod.rs
@@ -320,9 +320,9 @@ impl StandardLibrary {
                 }),
         );
 
-        // Intentionally not a merge, didn't seem valuable
+        // Merge Lua versions instead of replacing them
         if !other.lua_versions.is_empty() {
-            self.lua_versions = other.lua_versions;
+            self.lua_versions.extend(other.lua_versions);
         }
 
         self.globals = globals;


### PR DESCRIPTION
Previously, lua53.yml would lose Lua 5.3 support when extending lua52.yml, causing bitwise operators to fail parsing.

for #340, #645
