### PR TITLE
fix: forward Lua version features from selene-lib to CLI crate

### DIFF
--- a/selene/Cargo.toml
+++ b/selene/Cargo.toml
@@ -40,6 +40,10 @@ ureq = { version = "2.6.2", features = ["json"], optional = true }
 pretty_assertions = "1.3"
 
 [features]
-default = ["roblox"]
+default = ["lua52", "lua53", "lua54", "luajit", "roblox"]
 tracy-profiling = ["profiling/profile-with-tracy", "tracy-client"]
+lua52 = ["selene-lib/lua52", "full_moon/lua52"]
+lua53 = ["selene-lib/lua53", "full_moon/lua53"]
+lua54 = ["selene-lib/lua54", "full_moon/lua54"]
+luajit = ["selene-lib/luajit", "full_moon/luajit"]
 roblox = ["selene-lib/roblox", "full_moon/roblox", "ureq"]


### PR DESCRIPTION
The selene-lib crate defines lua52, lua53, lua54, and luajit as default features (enabling the corresponding full_moon parser features), but the selene CLI crate imports selene-lib with default-features = false and only re-exports the roblox feature. This means cargo install selene and the GitHub release binaries cannot parse Lua 5.2+ syntax (goto/labels), LuaJIT extensions (ULL number suffixes), or \x hex string escapes.

Forward all four Lua version features through the CLI crate and include them in its default feature set, matching selene-lib's own defaults.

Fixes #581

This PR was assisted by AI