### PR TITLE
Preserve standard-library metadata across simple local aliases of tables

### DIFF
--- a/selene-lib/src/ast_util/name_paths.rs
+++ b/selene-lib/src/ast_util/name_paths.rs
@@ -44,7 +44,7 @@ pub fn name_path(expression: &ast::Expression) -> Option<Vec<String>> {
                 name_path_from_prefix_suffix(expression.prefix(), expression.suffixes())
             }
 
-            ast::Var::Name(name) => Some(vec![name.to_string()]),
+            ast::Var::Name(name) => Some(vec![name.token().to_string()]),
 
             _ => None,
         }

--- a/selene-lib/src/ast_util/scopes.rs
+++ b/selene-lib/src/ast_util/scopes.rs
@@ -13,7 +13,7 @@ use id_arena::{Arena, Id};
 
 use crate::ast_util::extract_static_token;
 
-use super::expression_to_ident;
+use super::{expression_to_ident, name_paths::name_path};
 
 type Range = (usize, usize);
 
@@ -70,6 +70,32 @@ impl ScopeManager {
         }
 
         VariableInScope::NotFound
+    }
+
+    pub fn resolve_name_path(
+        &self,
+        byte: usize,
+        name_path: &[String],
+    ) -> Option<Vec<String>> {
+        let (head, tail) = name_path.split_first()?;
+        let Some(reference) = self.reference_at_byte(byte) else {
+            return Some(name_path.to_vec());
+        };
+        let Some(variable_id) = reference.resolved else {
+            return Some(name_path.to_vec());
+        };
+        let variable = self.variables.get(variable_id)?;
+
+        if variable.name != *head {
+            return None;
+        }
+
+        let mut resolved = match variable.value.as_ref()? {
+            AssignedValue::StaticTable { .. } => return None,
+            AssignedValue::Reference(name_path) => name_path.clone(),
+        };
+        resolved.extend_from_slice(tail);
+        Some(resolved)
     }
 }
 
@@ -150,6 +176,7 @@ pub struct Variable {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AssignedValue {
     StaticTable { has_fields: bool },
+    Reference(Vec<String>),
 }
 
 #[derive(Debug)]
@@ -198,6 +225,22 @@ fn create_scope<N: Node>(node: N) -> Option<Scope> {
 fn range<N: Node>(node: N) -> (usize, usize) {
     let (start, end) = node.range().unwrap();
     (start.bytes(), end.bytes())
+}
+
+// Lua assignments can have fewer RHS expressions than LHS names, so scope analysis pads the
+// missing RHS slots with None to keep name/expression pairing consistent.
+fn padded_expressions<'a, T>(
+    expressions: T,
+    count: usize,
+) -> Vec<Option<&'a ast::Expression>>
+where
+    T: Iterator<Item = &'a ast::Expression>,
+{
+    expressions
+        .map(Some)
+        .chain(std::iter::repeat(None))
+        .take(count)
+        .collect()
 }
 
 fn get_name_path_from_call(call: &ast::FunctionCall) -> Option<Vec<String>> {
@@ -263,16 +306,6 @@ fn get_name_path_from_call(call: &ast::FunctionCall) -> Option<Vec<String>> {
     Some(path)
 }
 
-fn get_assigned_value(expression: &ast::Expression) -> Option<AssignedValue> {
-    if let ast::Expression::TableConstructor(table_constructor) = expression {
-        return Some(AssignedValue::StaticTable {
-            has_fields: !table_constructor.fields().is_empty(),
-        });
-    }
-
-    None
-}
-
 impl ScopeVisitor {
     fn from_ast(ast: &ast::Ast) -> Self {
         if let Some(scope) = create_scope(ast.nodes()) {
@@ -327,6 +360,103 @@ impl ScopeVisitor {
         }
 
         None
+    }
+
+    fn get_assigned_value(&self, expression: &ast::Expression) -> Option<AssignedValue> {
+        if let ast::Expression::TableConstructor(table_constructor) = expression {
+            return Some(AssignedValue::StaticTable {
+                has_fields: !table_constructor.fields().is_empty(),
+            });
+        }
+
+        let name_path = name_path(expression)?;
+        let (head, tail) = name_path.split_first()?;
+
+        let Some(reference) = self
+            .scope_manager
+            .reference_at_byte(expression.start_position()?.bytes())
+        else {
+            return Some(AssignedValue::Reference(name_path));
+        };
+
+        let Some(variable_id) = reference.resolved else {
+            return Some(AssignedValue::Reference(name_path));
+        };
+
+        let variable = self.scope_manager.variables.get(variable_id)?;
+
+        if variable.name != *head {
+            return None;
+        }
+
+        match variable.value.as_ref()? {
+            AssignedValue::StaticTable { has_fields } if tail.is_empty() => Some(
+                AssignedValue::StaticTable {
+                    has_fields: *has_fields,
+                },
+            ),
+            AssignedValue::StaticTable { .. } => None,
+            AssignedValue::Reference(resolved) => {
+                let mut resolved = resolved.clone();
+                resolved.extend_from_slice(tail);
+                Some(AssignedValue::Reference(resolved))
+            }
+        }
+    }
+
+    fn update_assigned_value(
+        &mut self,
+        variable_id: Id<Variable>,
+        value: Option<AssignedValue>,
+    ) {
+        self.scope_manager.variables.get_mut(variable_id).unwrap().value = value;
+    }
+
+    fn bind_declared_names<'a, I, E>(
+        &mut self,
+        names: I,
+        expressions: E,
+        definition_range: Range,
+    ) where
+        I: Iterator<Item = &'a TokenReference>,
+        E: Iterator<Item = &'a ast::Expression>,
+    {
+        let names = names.collect::<Vec<_>>();
+        let expressions = padded_expressions(expressions, names.len());
+
+        // Local-like declarations evaluate all RHS expressions before any of the new names enter
+        // scope, so alias/value tracking has to be resolved before defining the new bindings.
+        let values = expressions
+            .iter()
+            .copied()
+            .map(|expression| {
+                if let Some(expression) = expression {
+                    self.read_expression(expression);
+                }
+
+                expression.and_then(|expression| self.get_assigned_value(expression))
+            })
+            .collect::<Vec<_>>();
+
+        for ((name_token, expression), value) in names
+            .into_iter()
+            .zip(expressions.iter().copied())
+            .zip(values.into_iter())
+        {
+            self.define_name_full_with_variable(
+                &name_token.token().to_string(),
+                range(name_token),
+                definition_range,
+                Variable {
+                    value,
+                    ..Default::default()
+                },
+            );
+
+            if let Some(expression) = expression {
+                self.write_name(name_token, Some(range(expression)));
+            }
+        }
     }
 
     fn read_expression(&mut self, expression: &ast::Expression) {
@@ -576,24 +706,17 @@ impl ScopeVisitor {
         self.define_name_full_with_variable(name, range, definition_range, Variable::default())
     }
 
-    fn try_hoist(&mut self) {
-        let latest_reference_id = *self.current_scope().references.last().unwrap();
-        let (name, identifier, write_expr) = {
-            let reference = self
-                .scope_manager
-                .references
-                .get(latest_reference_id)
-                .unwrap();
-
-            (
-                reference.name.to_owned(),
-                reference.identifier,
-                reference.identifier, // This is the write_expr, but it's not great
-            )
-        };
-
+    fn hoist_name(&mut self, name: String, identifier: Range, write_expr: Range, value: Option<AssignedValue>) {
         if self.find_variable(&name).is_none() {
-            let id = self.define_name_full(&name, identifier, write_expr);
+            let id = self.define_name_full_with_variable(
+                &name,
+                identifier,
+                write_expr,
+                Variable {
+                    value,
+                    ..Default::default()
+                },
+            );
 
             for (_, reference) in &mut self.scope_manager.references {
                 if reference.read && reference.name == name && reference.resolved.is_none() {
@@ -601,6 +724,32 @@ impl ScopeVisitor {
                 }
             }
         }
+    }
+
+    // Returns the most recent bare-name write target so it can be hoisted after RHS analysis.
+    fn current_pending_hoist(&self) -> Option<(String, Range, Range)> {
+        let latest_reference_id = *self
+            .scope_manager
+            .scopes
+            .get(self.current_scope_id())?
+            .references
+            .last()?;
+        let reference = self.scope_manager.references.get(latest_reference_id)?;
+
+        Some((
+            reference.name.to_owned(),
+            reference.identifier,
+            reference.identifier, // This is the write_expr, but it's not great
+        ))
+    }
+
+    // Hoists the current bare-name write target, optionally attaching an alias/value snapshot.
+    fn hoist_pending(&mut self, value: Option<AssignedValue>) {
+        let Some((name, identifier, write_expr)) = self.current_pending_hoist() else {
+            return;
+        };
+
+        self.hoist_name(name, identifier, write_expr, value);
     }
 
     fn reference_variable(&mut self, name: &str, mut reference: Reference) {
@@ -643,6 +792,10 @@ impl ScopeVisitor {
 
     fn process_function_call_finish(&mut self, call: &ast::FunctionCall) {
         let name_path = match get_name_path_from_call(call) {
+            Some(name_path) => name_path,
+            None => return,
+        };
+        let name_path = match self.scope_manager.resolve_name_path(range(call).0, &name_path) {
             Some(name_path) => name_path,
             None => return,
         };
@@ -772,10 +925,15 @@ impl ScopeVisitor {
 
 impl Visitor for ScopeVisitor {
     fn visit_assignment(&mut self, assignment: &ast::Assignment) {
-        let mut expressions = assignment.expressions().iter();
+        let expressions =
+            padded_expressions(assignment.expressions().iter(), assignment.variables().iter().count());
 
-        for var in assignment.variables() {
-            let expression = expressions.next();
+        // Lua evaluates all RHS expressions before updating any LHS variables, so alias/value
+        // tracking has to mirror that ordering for multi-assignments like `a, b = b, a`.
+        let mut pending_value_updates = Vec::new();
+        let mut pending_hoists = Vec::new();
+
+        for (var, expression) in assignment.variables().iter().zip(expressions.iter().copied()) {
             if let Some(expression) = expression {
                 self.read_expression(expression);
             }
@@ -809,64 +967,43 @@ impl Visitor for ScopeVisitor {
                 _ => continue,
             };
 
+            let existing_variable = self.find_variable(&name.token().to_string()).map(|(id, _)| id);
+            let assigned_value = expression.and_then(|expression| self.get_assigned_value(expression));
+
             self.write_name(name, expression.map(range));
             if let ast::Var::Name(_) = var {
-                self.try_hoist();
+                if let Some(variable_id) = existing_variable {
+                    pending_value_updates.push((variable_id, assigned_value));
+                } else if let Some((name, identifier, write_expr)) = self.current_pending_hoist() {
+                    pending_hoists.push((name, identifier, write_expr, assigned_value));
+                }
             }
+        }
+
+        for (name, identifier, write_expr, value) in pending_hoists {
+            self.hoist_name(name, identifier, write_expr, value);
+        }
+
+        for (variable_id, value) in pending_value_updates {
+            self.update_assigned_value(variable_id, value);
         }
     }
 
     fn visit_local_assignment(&mut self, local_assignment: &ast::LocalAssignment) {
-        let mut expressions = local_assignment.expressions().iter();
-
-        for name_token in local_assignment.names() {
-            let expression = expressions.next();
-
-            if let Some(expression) = expression {
-                self.read_expression(expression);
-            }
-
-            self.define_name_full_with_variable(
-                &name_token.token().to_string(),
-                range(name_token),
-                range(local_assignment),
-                Variable {
-                    value: expression.and_then(get_assigned_value),
-                    ..Default::default()
-                },
-            );
-
-            if let Some(expression) = expression {
-                self.write_name(name_token, Some(range(expression)));
-            }
-        }
+        self.bind_declared_names(
+            local_assignment.names().iter(),
+            local_assignment.expressions().iter(),
+            range(local_assignment),
+        );
     }
 
     #[cfg(feature = "roblox")]
     fn visit_const_assignment(&mut self, const_assignment: &ConstAssignment) {
-        let mut expressions = const_assignment.expressions().iter();
-
-        for name_token in const_assignment.names() {
-            let expression = expressions.next();
-
-            if let Some(expression) = expression {
-                self.read_expression(expression);
-            }
-
-            self.define_name_full_with_variable(
-                &name_token.token().to_string(),
-                range(name_token),
-                range(const_assignment),
-                Variable {
-                    value: expression.and_then(get_assigned_value),
-                    ..Default::default()
-                },
-            );
-
-            if let Some(expression) = expression {
-                self.write_name(name_token, Some(range(expression)));
-            }
-        }
+        self.bind_declared_names(
+            const_assignment.names().iter(),
+            const_assignment.expressions().iter(),
+            range(const_assignment),
+        );
     }
 
     fn visit_block(&mut self, block: &ast::Block) {
@@ -984,7 +1121,7 @@ impl Visitor for ScopeVisitor {
         self.read_name(base);
 
         if !is_longer_expression {
-            self.try_hoist();
+            self.hoist_pending(None);
         }
 
         if let Some(name) = name.method_name() {

--- a/selene-lib/src/lints/must_use.rs
+++ b/selene-lib/src/lints/must_use.rs
@@ -63,4 +63,24 @@ mod tests {
     fn test_must_use() {
         test_lint(MustUseLint::new(()).unwrap(), "must_use", "must_use");
     }
+
+    #[test]
+    fn test_must_use_aliasing() {
+        test_lint(MustUseLint::new(()).unwrap(), "must_use", "aliasing");
+    }
+
+    #[test]
+    fn test_must_use_reassign() {
+        test_lint(MustUseLint::new(()).unwrap(), "must_use", "reassign");
+    }
+
+    #[test]
+    fn test_must_use_reassign_alias() {
+        test_lint(MustUseLint::new(()).unwrap(), "must_use", "reassign_alias");
+    }
+
+    #[test]
+    fn test_must_use_reassign_multi() {
+        test_lint(MustUseLint::new(()).unwrap(), "must_use", "reassign_multi");
+    }
 }

--- a/selene-lib/src/lints/standard_library.rs
+++ b/selene-lib/src/lints/standard_library.rs
@@ -210,6 +210,11 @@ pub struct StandardLibraryVisitor<'std> {
 }
 
 impl StandardLibraryVisitor<'_> {
+    fn resolved_name_path(&self, byte: usize, name_path: Vec<String>) -> Option<Vec<String>> {
+        self.scope_manager
+            .resolve_name_path(byte, &name_path)
+    }
+
     fn lint_invalid_field_access(
         &mut self,
         mut name_path: Vec<String>,
@@ -367,30 +372,17 @@ impl Visitor for StandardLibraryVisitor<'_> {
     }
 
     fn visit_expression(&mut self, expression: &ast::Expression) {
-        if let Some(reference) = self
-            .scope_manager
-            .reference_at_byte(expression.start_position().unwrap().bytes())
-        {
-            if reference.resolved.is_some() {
-                return;
-            }
-        }
-
         if let Some(name_path) = name_path(expression) {
+            let Some(name_path) =
+                self.resolved_name_path(expression.start_position().unwrap().bytes(), name_path)
+            else {
+                return;
+            };
             self.lint_invalid_field_access(name_path, expression.range().unwrap());
         }
     }
 
     fn visit_function_call(&mut self, call: &ast::FunctionCall) {
-        if let Some(reference) = self
-            .scope_manager
-            .reference_at_byte(call.start_position().unwrap().bytes())
-        {
-            if reference.resolved.is_some() {
-                return;
-            }
-        }
-
         let mut keep_going = true;
         let mut suffixes: Vec<&ast::Suffix> = call
             .suffixes()
@@ -402,6 +394,11 @@ impl Visitor for StandardLibraryVisitor<'_> {
                 Some(name_path) => name_path,
                 None => return,
             };
+        name_path = match self.resolved_name_path(call.start_position().unwrap().bytes(), name_path)
+        {
+            Some(name_path) => name_path,
+            None => return,
+        };
 
         let call_suffix = suffixes.pop().unwrap();
 
@@ -738,11 +735,47 @@ mod tests {
     }
 
     #[test]
+    fn test_aliasing() {
+        test_lint(
+            StandardLibraryLint::new(()).unwrap(),
+            "standard_library",
+            "aliasing",
+        );
+    }
+
+    #[test]
     fn test_assert() {
         test_lint(
             StandardLibraryLint::new(()).unwrap(),
             "standard_library",
             "assert",
+        );
+    }
+
+    #[test]
+    fn test_reassign() {
+        test_lint(
+            StandardLibraryLint::new(()).unwrap(),
+            "standard_library",
+            "reassign",
+        );
+    }
+
+    #[test]
+    fn test_reassign_alias() {
+        test_lint(
+            StandardLibraryLint::new(()).unwrap(),
+            "standard_library",
+            "reassign_alias",
+        );
+    }
+
+    #[test]
+    fn test_reassign_multi() {
+        test_lint(
+            StandardLibraryLint::new(()).unwrap(),
+            "standard_library",
+            "reassign_multi",
         );
     }
 

--- a/selene-lib/tests/lints/must_use/aliasing.lua
+++ b/selene-lib/tests/lints/must_use/aliasing.lua
@@ -1,0 +1,8 @@
+local math2 = math
+
+-- This should fail: math2 aliases math, and math.max is marked must_use.
+math2.max(x, y)
+
+-- This should fail too: plain assignment should preserve the alias even without `local`.
+math_global = math
+math_global.max(x, y)

--- a/selene-lib/tests/lints/must_use/aliasing.stderr
+++ b/selene-lib/tests/lints/must_use/aliasing.stderr
@@ -1,0 +1,12 @@
+error[must_use]: unused return value of `math.max` must be used
+  ┌─ aliasing.lua:4:1
+  │
+4 │ math2.max(x, y)
+  │ ^^^^^^^^^
+
+error[must_use]: unused return value of `math.max` must be used
+  ┌─ aliasing.lua:8:1
+  │
+8 │ math_global.max(x, y)
+  │ ^^^^^^^^^^^^^^^
+

--- a/selene-lib/tests/lints/must_use/reassign.lua
+++ b/selene-lib/tests/lints/must_use/reassign.lua
@@ -1,0 +1,10 @@
+local math2 = math
+local custom_math = {}
+
+function custom_math.max(a, b)
+    return a + b
+end
+
+-- This should not fail: once math2 is reassigned, math.max's must_use no longer applies.
+math2 = custom_math
+math2.max(1, 2)

--- a/selene-lib/tests/lints/must_use/reassign_alias.lua
+++ b/selene-lib/tests/lints/must_use/reassign_alias.lua
@@ -1,0 +1,5 @@
+local math2 = {}
+
+-- This should fail: reassignment to math should re-establish math.max's must_use behavior.
+math2 = math
+math2.max(x, y)

--- a/selene-lib/tests/lints/must_use/reassign_alias.stderr
+++ b/selene-lib/tests/lints/must_use/reassign_alias.stderr
@@ -1,0 +1,6 @@
+error[must_use]: unused return value of `math.max` must be used
+  ┌─ reassign_alias.lua:5:1
+  │
+5 │ math2.max(x, y)
+  │ ^^^^^^^^^
+

--- a/selene-lib/tests/lints/must_use/reassign_multi.lua
+++ b/selene-lib/tests/lints/must_use/reassign_multi.lua
@@ -1,0 +1,13 @@
+local a = math
+local b = {}
+
+-- This should fail: after swapping, b should now refer to math.
+a, b = b, a
+b.max(x, y)
+
+local c = math
+local d = {}
+
+-- This should fail too: the second RHS `c` must read the outer `c`, not the new local `c`.
+local c, d = d, c
+d.max(x, y)

--- a/selene-lib/tests/lints/must_use/reassign_multi.stderr
+++ b/selene-lib/tests/lints/must_use/reassign_multi.stderr
@@ -1,0 +1,12 @@
+error[must_use]: unused return value of `math.max` must be used
+  ┌─ reassign_multi.lua:6:1
+  │
+6 │ b.max(x, y)
+  │ ^^^^^
+
+error[must_use]: unused return value of `math.max` must be used
+   ┌─ reassign_multi.lua:13:1
+   │
+13 │ d.max(x, y)
+   │ ^^^^^
+

--- a/selene-lib/tests/lints/standard_library/aliasing.lua
+++ b/selene-lib/tests/lints/standard_library/aliasing.lua
@@ -1,0 +1,18 @@
+local ecs = z2.ecs
+local ecs2 = ecs
+
+-- This should not fail: ecs aliases z2.ecs, and create_entity is called correctly.
+local id = ecs.create_entity()
+-- This should fail: ecs2 aliases z2.ecs, so create_entity still expects 0 args.
+local e = ecs2.create_entity(3)
+-- This should fail: ecs2 still points at z2.ecs, so misspelled fields should be checked too.
+local g = ecs2.create_enztity()
+
+-- This should fail too: plain assignment should preserve the alias even without `local`.
+ecs_global = z2.ecs
+local h = ecs_global.create_entity(3)
+
+local z2 = {}
+local ecs3 = z2
+-- This should not fail: this z2 is just a local table, so create_entity is not checked as a std function.
+local f = ecs3.create_entity(3)

--- a/selene-lib/tests/lints/standard_library/aliasing.std.yml
+++ b/selene-lib/tests/lints/standard_library/aliasing.std.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  z2.ecs.create_entity:
+    args: []
+    must_use: true

--- a/selene-lib/tests/lints/standard_library/aliasing.stderr
+++ b/selene-lib/tests/lints/standard_library/aliasing.stderr
@@ -1,0 +1,18 @@
+error[incorrect_standard_library_use]: standard library function `z2.ecs.create_entity` requires 0 parameters, 1 passed
+  ┌─ aliasing.lua:7:11
+  │
+7 │ local e = ecs2.create_entity(3)
+  │           ^^^^^^^^^^^^^^^^^^^^^
+
+error[incorrect_standard_library_use]: standard library global `z2.ecs` does not contain the field `create_enztity`
+  ┌─ aliasing.lua:9:11
+  │
+9 │ local g = ecs2.create_enztity()
+  │           ^^^^^^^^^^^^^^^^^^^
+
+error[incorrect_standard_library_use]: standard library function `z2.ecs.create_entity` requires 0 parameters, 1 passed
+   ┌─ aliasing.lua:13:11
+   │
+13 │ local h = ecs_global.create_entity(3)
+   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/selene-lib/tests/lints/standard_library/reassign.lua
+++ b/selene-lib/tests/lints/standard_library/reassign.lua
@@ -1,0 +1,5 @@
+local ecs = z2.ecs
+
+-- This should not fail: once ecs is reassigned, it should no longer be checked as z2.ecs.
+ecs = {}
+local id = ecs.create_entity(3)

--- a/selene-lib/tests/lints/standard_library/reassign.std.yml
+++ b/selene-lib/tests/lints/standard_library/reassign.std.yml
@@ -1,0 +1,4 @@
+---
+globals:
+  z2.ecs.create_entity:
+    args: []

--- a/selene-lib/tests/lints/standard_library/reassign_alias.lua
+++ b/selene-lib/tests/lints/standard_library/reassign_alias.lua
@@ -1,0 +1,5 @@
+local ecs = {}
+
+-- This should fail: reassignment to z2.ecs should re-establish the std alias.
+ecs = z2.ecs
+local id = ecs.create_entity(3)

--- a/selene-lib/tests/lints/standard_library/reassign_alias.std.yml
+++ b/selene-lib/tests/lints/standard_library/reassign_alias.std.yml
@@ -1,0 +1,4 @@
+---
+globals:
+  z2.ecs.create_entity:
+    args: []

--- a/selene-lib/tests/lints/standard_library/reassign_alias.stderr
+++ b/selene-lib/tests/lints/standard_library/reassign_alias.stderr
@@ -1,0 +1,6 @@
+error[incorrect_standard_library_use]: standard library function `z2.ecs.create_entity` requires 0 parameters, 1 passed
+  ┌─ reassign_alias.lua:5:12
+  │
+5 │ local id = ecs.create_entity(3)
+  │            ^^^^^^^^^^^^^^^^^^^^
+

--- a/selene-lib/tests/lints/standard_library/reassign_multi.lua
+++ b/selene-lib/tests/lints/standard_library/reassign_multi.lua
@@ -1,0 +1,13 @@
+local a = z2.ecs
+local b = {}
+
+-- This should fail: after swapping, b should now refer to z2.ecs.
+a, b = b, a
+local id = b.create_entity(3)
+
+local c = z2.ecs
+local d = {}
+
+-- This should fail too: the second RHS `c` must read the outer `c`, not the new local `c`.
+local c, d = d, c
+local id2 = d.create_entity(3)

--- a/selene-lib/tests/lints/standard_library/reassign_multi.std.yml
+++ b/selene-lib/tests/lints/standard_library/reassign_multi.std.yml
@@ -1,0 +1,4 @@
+---
+globals:
+  z2.ecs.create_entity:
+    args: []

--- a/selene-lib/tests/lints/standard_library/reassign_multi.stderr
+++ b/selene-lib/tests/lints/standard_library/reassign_multi.stderr
@@ -1,0 +1,12 @@
+error[incorrect_standard_library_use]: standard library function `z2.ecs.create_entity` requires 0 parameters, 1 passed
+  ┌─ reassign_multi.lua:6:12
+  │
+6 │ local id = b.create_entity(3)
+  │            ^^^^^^^^^^^^^^^^^^
+
+error[incorrect_standard_library_use]: standard library function `z2.ecs.create_entity` requires 0 parameters, 1 passed
+   ┌─ reassign_multi.lua:13:13
+   │
+13 │ local id2 = d.create_entity(3)
+   │             ^^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Calls via local aliases of tables did not lint correctly.  For example, given the below code with warnings:

```
  math.max(1,3)    -- unused return value of `math.max` must be used
```
But if you call max via a local alias:

```
  local math2 = math
  math2.max(1,3)   -- no warning at all
```

In Lua codebases with nested namespaces, this becomes a problem, because Selene's linting ability is completely lost on code like below:

```
  local ecs = z2.ecs   -- grab ecs submodule from z2
  local e = ecs.create_entity(3) -- selene doesn't know about create_entity
```

This commit beefs up selene to track standard-library metadata tracking via such aliases as follows:

1. When Selene sees an assignment from a known path like `z2.ecs` or `math`, it stores that origin on the assigned variable.

   Example: after `local ecs = z2.ecs`, Selene records that `ecs` is an alias of the path `z2.ecs`.

2. When Selene later sees a call or field access through that variable, it tries to recover the original path before doing standard-library checks.

   Example: `ecs.create_entity(3)` can be treated like `z2.ecs.create_entity(3)`.

3. Selene only does that for variables that are known aliases of an existing path, not for arbitrary locals.

   Example: `local z2 = {}; local ecs = z2` should stay local data, not accidentally turn into the standard-library `z2.ecs`.

LLM disclosure: I did use codex in development of this change.  I did however iterate on this a fair bit, reviewing, writing tests, improving test coverage, and IMO the feature is well-tested and high quality.  I'm not a professional Rust coder though, so I wouldn't be surprised if the Rust code could be improved even further.

fixes #675