### PR TITLE
Add `permitted-inline-allows` config to restrict inline allow filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.31.0...HEAD)
+### Added
+- Added a new `permitted-inline-allows` configuration option that restricts which lints may be silenced with an inline `-- selene: allow(...)` (or file-wide `--# selene: allow(...)`) filter. When set, an `allow(...)` for any other lint produces an `invalid_lint_filter` diagnostic and is ignored, so the underlying lint still fires. Only the `allow` variation is restricted; `deny`/`warn` are unaffected.
 
 ## [0.31.0](https://github.com/Kampfkarren/selene/releases/tag/0.31.0) - 2026-05-20
 ### Fixed

--- a/docs/src/usage/configuration.md
+++ b/docs/src/usage/configuration.md
@@ -69,3 +69,12 @@ It is possible to exclude files from being linted using the exclude option:
 ```toml
 exclude = ["external/*", "*.spec.lua"]
 ```
+
+### Restricting which lints can be silenced inline
+By default, any lint can be silenced with an inline `-- selene: allow(...)` filter. You can restrict this to a specific set of lints with the `permitted-inline-allows` option:
+
+```toml
+permitted-inline-allows = ["unused_variable"]
+```
+
+With this set, an `allow(...)` naming any other lint is reported as an `invalid_lint_filter` error and is ignored, so the underlying lint still fires. Only the `allow` variation is affected; `deny` and `warn` are always permitted. See [Filtering](./filtering.md#restricting-which-lints-can-be-silenced-inline) for more details.

--- a/docs/src/usage/filtering.md
+++ b/docs/src/usage/filtering.md
@@ -98,3 +98,33 @@ You can filter multiple lints in two ways:
 
 -- selene: allow(lint_one, lint_two)
 ```
+
+## Restricting which lints can be silenced inline
+By default, any lint can be silenced with an inline `allow(...)` filter. In larger codebases you may want to guarantee that only a specific set of lints can be silenced this way. For example, you might permit `unused_variable` to be silenced while ensuring `undefined_variable` can never be locally suppressed and must instead be fixed.
+
+The `permitted-inline-allows` option restricts which lints may be silenced with an inline `-- selene: allow(...)` (or file-wide `--# selene: allow(...)`) filter:
+
+```toml
+# Only these lints may be silenced with an `allow(...)` filter.
+# Omit the option entirely to keep the default behavior (any lint may be silenced).
+permitted-inline-allows = ["unused_variable"]
+```
+
+With this configuration, an `allow(...)` naming any other lint is reported as an `invalid_lint_filter` error, and the underlying lint still fires:
+
+```lua
+-- selene: allow(undefined_variable)
+foo()
+```
+
+```
+error[invalid_lint_filter]: lint `undefined_variable` may not be silenced with an `allow(...)` filter
+  ┌─ code.lua:1:1
+  │
+1 │ -- selene: allow(undefined_variable)
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[undefined_variable]: `foo` is not defined
+```
+
+Only the `allow` variation is restricted; `deny` and `warn` filters, which raise a lint's severity, are always permitted. Each lint in a multi-lint filter such as `allow(unused_variable, undefined_variable)` is evaluated independently.

--- a/selene-lib/src/lib.rs
+++ b/selene-lib/src/lib.rs
@@ -3,7 +3,11 @@
     feature = "force_exhaustive_checks",
     feature(non_exhaustive_omitted_patterns_lint)
 )]
-use std::{collections::HashMap, error::Error, fmt};
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    fmt,
+};
 
 use full_moon::ast::Ast;
 use serde::{
@@ -68,6 +72,15 @@ pub struct CheckerConfig<V> {
     pub std: Option<String>,
     pub exclude: Vec<String>,
 
+    /// When set, only these lints may be silenced with an inline
+    /// `-- selene: allow(...)` (or file-wide `--# selene: allow(...)`) filter.
+    /// Any other lint named in an `allow(...)` filter produces an
+    /// `invalid_lint_filter` diagnostic and is ignored, so the underlying lint
+    /// still fires. `None` (the default) preserves the original behavior where
+    /// any lint may be silenced inline. Only the `allow` variation is
+    /// restricted; `deny`/`warn` are unaffected.
+    pub permitted_inline_allows: Option<HashSet<String>>,
+
     // Not locked behind Roblox feature so that selene.toml for Roblox will
     // run even without it.
     pub roblox_std_source: RobloxStdSource,
@@ -86,6 +99,7 @@ impl<V> Default for CheckerConfig<V> {
             lints: HashMap::new(),
             std: None,
             exclude: Vec::new(),
+            permitted_inline_allows: None,
 
             roblox_std_source: RobloxStdSource::default(),
         }
@@ -264,6 +278,7 @@ macro_rules! use_lints {
                     ast,
                     diagnostics,
                     self.get_lint_severity(&self.invalid_lint_filter, "invalid_lint_filter"),
+                    self.config.permitted_inline_allows.as_ref(),
                 );
 
                 diagnostics

--- a/selene-lib/src/lint_filtering.rs
+++ b/selene-lib/src/lint_filtering.rs
@@ -34,10 +34,10 @@ struct Filter {
     range: (usize, usize),
 }
 
-#[derive(Default)]
-struct FilterVisitor {
+struct FilterVisitor<'a> {
     comments_checked: HashSet<(usize, usize)>,
     ranges: Vec<Result<Filter, Diagnostic>>,
+    permitted_inline_allows: Option<&'a HashSet<String>>,
 }
 
 pub fn parse_comment(comment_original: &str) -> Option<Vec<FilterConfiguration>> {
@@ -90,7 +90,7 @@ pub fn parse_comment(comment_original: &str) -> Option<Vec<FilterConfiguration>>
     )
 }
 
-impl NodeVisitor for FilterVisitor {
+impl NodeVisitor for FilterVisitor<'_> {
     fn visit_node(&mut self, node: &dyn Node, visitor_type: VisitorType) {
         if NODES_TO_IGNORE.contains(&visitor_type) {
             return;
@@ -130,35 +130,61 @@ impl NodeVisitor for FilterVisitor {
                     )
                 });
 
-                self.ranges
-                    .extend(configurations.into_iter().map(|configuration| {
-                        if lint_exists(&configuration.lint) {
-                            Ok(Filter {
-                                configuration,
-                                comment_range: (
-                                    trivia.start_position().bytes(),
-                                    trivia.end_position().bytes(),
-                                ),
-                                range: (range.0.bytes(), range.1.bytes()),
-                            })
-                        } else {
-                            Err(Diagnostic::new(
-                                "invalid_lint_filter",
-                                format!("no lint named `{}` exists", configuration.lint),
-                                Label::new((
-                                    trivia_start_position.bytes(),
-                                    trivia_end_position.bytes(),
-                                )),
-                            ))
-                        }
-                    }));
+                let permitted_inline_allows = self.permitted_inline_allows;
+
+                for configuration in configurations {
+                    let comment_range = (
+                        trivia.start_position().bytes(),
+                        trivia.end_position().bytes(),
+                    );
+
+                    // When an allowlist is configured, only the listed lints may
+                    // be silenced with an `allow(...)` filter. `deny`/`warn` raise
+                    // a lint's severity and are never restricted.
+                    let disallowed_allow = configuration.variation == LintVariation::Allow
+                        && permitted_inline_allows
+                            .map(|allowed| !allowed.contains(&configuration.lint))
+                            .unwrap_or(false);
+
+                    let filter = if !lint_exists(&configuration.lint) {
+                        Err(Diagnostic::new(
+                            "invalid_lint_filter",
+                            format!("no lint named `{}` exists", configuration.lint),
+                            Label::new(comment_range),
+                        ))
+                    } else if disallowed_allow {
+                        Err(Diagnostic::new(
+                            "invalid_lint_filter",
+                            format!(
+                                "lint `{}` may not be silenced with an `allow(...)` filter",
+                                configuration.lint
+                            ),
+                            Label::new(comment_range),
+                        ))
+                    } else {
+                        Ok(Filter {
+                            configuration,
+                            comment_range,
+                            range: (range.0.bytes(), range.1.bytes()),
+                        })
+                    };
+
+                    self.ranges.push(filter);
+                }
             }
         }
     }
 }
 
-fn get_filter_ranges(ast: &Ast) -> Vec<Result<Filter, Diagnostic>> {
-    let mut filter_visitor = FilterVisitor::default();
+fn get_filter_ranges(
+    ast: &Ast,
+    permitted_inline_allows: Option<&HashSet<String>>,
+) -> Vec<Result<Filter, Diagnostic>> {
+    let mut filter_visitor = FilterVisitor {
+        comments_checked: HashSet::new(),
+        ranges: Vec::new(),
+        permitted_inline_allows,
+    };
     filter_visitor.visit_nodes(ast);
     filter_visitor.ranges
 }
@@ -188,8 +214,9 @@ pub fn filter_diagnostics(
     ast: &Ast,
     mut diagnostics: Vec<CheckerDiagnostic>,
     invalid_lint_filter_severity: Severity,
+    permitted_inline_allows: Option<&HashSet<String>>,
 ) -> Vec<CheckerDiagnostic> {
-    let filter_ranges = get_filter_ranges(ast);
+    let filter_ranges = get_filter_ranges(ast, permitted_inline_allows);
     let (mut filters, mut failures) = (Vec::new(), Vec::new());
     let mut new_diagnostics;
 
@@ -351,7 +378,7 @@ mod tests {
         test_util::{test_full_run, test_full_run_config},
         CheckerConfig, LintVariation,
     };
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn test_lint_filtering() {
@@ -379,6 +406,18 @@ mod tests {
                     map.insert("unused_variable".to_owned(), LintVariation::Allow);
                     map
                 },
+                ..CheckerConfig::default()
+            },
+        );
+    }
+
+    #[test]
+    fn test_permitted_inline_allows() {
+        test_full_run_config(
+            "lint_filtering",
+            "permitted_inline_allows",
+            CheckerConfig {
+                permitted_inline_allows: Some(HashSet::from(["unused_variable".to_owned()])),
                 ..CheckerConfig::default()
             },
         );

--- a/selene-lib/tests/full_run/lint_filtering/permitted_inline_allows.lua
+++ b/selene-lib/tests/full_run/lint_filtering/permitted_inline_allows.lua
@@ -1,0 +1,14 @@
+-- (a) `unused_variable` is on the allowlist, so it can still be silenced inline.
+-- selene: allow(unused_variable)
+local unused_but_allowed = 1
+
+-- (b) `undefined_variable` is not on the allowlist. The filter is rejected with
+-- an invalid_lint_filter diagnostic, and the undefined_variable error still fires.
+-- selene: allow(undefined_variable)
+print(undefined_global_b())
+
+-- (c) In a multi-lint filter each entry is handled independently: the
+-- `unused_variable` half is honored, but the `undefined_variable` half is
+-- rejected and still fires.
+-- selene: allow(unused_variable, undefined_variable)
+local unused_c = undefined_global_c()

--- a/selene-lib/tests/full_run/lint_filtering/permitted_inline_allows.stderr
+++ b/selene-lib/tests/full_run/lint_filtering/permitted_inline_allows.stderr
@@ -1,0 +1,24 @@
+error[invalid_lint_filter]: lint `undefined_variable` may not be silenced with an `allow(...)` filter
+  ┌─ permitted_inline_allows.lua:7:1
+  │
+7 │ -- selene: allow(undefined_variable)
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[undefined_variable]: `undefined_global_b` is not defined
+  ┌─ permitted_inline_allows.lua:8:7
+  │
+8 │ print(undefined_global_b())
+  │       ^^^^^^^^^^^^^^^^^^
+
+error[invalid_lint_filter]: lint `undefined_variable` may not be silenced with an `allow(...)` filter
+   ┌─ permitted_inline_allows.lua:13:1
+   │
+13 │ -- selene: allow(unused_variable, undefined_variable)
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[undefined_variable]: `undefined_global_c` is not defined
+   ┌─ permitted_inline_allows.lua:14:18
+   │
+14 │ local unused_c = undefined_global_c()
+   │                  ^^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Closes #680.

## What
Adds a `permitted-inline-allows` configuration option that restricts which lints may be silenced with an inline `-- selene: allow(...)` (or file-wide `--# selene: allow(...)`) filter:

```toml
# Only these lints may be silenced with an `allow(...)` filter.
permitted-inline-allows = ["unused_variable"]
```

When set, an `allow(...)` naming any other lint is reported as an `invalid_lint_filter` error and is ignored, so the underlying lint still fires. Only the `allow` variation is restricted; `deny`/`warn`, which raise severity, are unaffected. The option defaults to unset, preserving today's behavior where any lint may be silenced inline.

## Why
An inline `allow(...)` filter attaches to the entire next AST node, so a comment meant to silence one lint on one construct silences it across a whole function or block. In larger codebases and CI setups, teams often want to permit a narrow set of benign inline suppressions (e.g. `unused_variable`) while guaranteeing that more serious lints (e.g. `undefined_variable`) can never be locally silenced and must be fixed instead. There is currently no way to enforce that.

Related: #382 (same attach-to-whole-node behavior), #214 (the lint most commonly masked).

## How
- New `CheckerConfig.permitted_inline_allows: Option<HashSet<String>>` (serde default `None` = permissive).
- Threaded through `filter_diagnostics` -> `get_filter_ranges` -> `FilterVisitor`.
- In `FilterVisitor::visit_node`: a lint that is `allow`-ed but not on the list yields `invalid_lint_filter` and no filter is built; unknown lint names keep the existing "no lint named X" error; each entry in a multi-lint filter is evaluated independently.

## Tests and docs
- New golden test `test_permitted_inline_allows` covering (a) `allow(unused_variable)` still suppresses, (b) `allow(undefined_variable)` is rejected and the error still fires, (c) `allow(unused_variable, undefined_variable)` handled per entry.
- Documented in `docs/src/usage/filtering.md` and `configuration.md`; CHANGELOG updated.
- `cargo test`, `cargo fmt --check`, and `cargo clippy` pass; existing behavior is unchanged (default is permissive).
