### PR TITLE
Add `Checker::test_on_with` to pass opaque data to lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/Kampfkarren/selene/compare/0.31.0...HEAD)
+### Added
+- `selene-lib`: added `Checker::test_on_with`, letting a library caller pass opaque, per-check data to lints. Lints retrieve it by type via `AstContext::caller_data`, providing a structured channel for handing per-file context to a lint without encoding it in the source or AST.
 
 ## [0.31.0](https://github.com/Kampfkarren/selene/releases/tag/0.31.0) - 2026-05-20
 ### Fixed

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -47,6 +47,29 @@ The implementation of `pass` is completely up to you, but there are a few common
 - Creating a visitor over the ast provided and creating diagnostics based off of that. See [`divide_by_zero`](https://github.com/Kampfkarren/selene/blob/master/selene-lib/src/lints/divide_by_zero.rs) and [`suspicious_reverse_loop`](https://github.com/Kampfkarren/selene/blob/master/selene-lib/src/lints/suspicious_reverse_loop.rs) for straight forward examples.
 - Using the `ScopeManager` struct to lint based off of usage of variables and references. See [`shadowing`](https://github.com/Kampfkarren/selene/blob/master/selene-lib/src/lints/shadowing.rs) and [`global_usage`](https://github.com/Kampfkarren/selene/blob/master/selene-lib/src/lints/global_usage.rs).
 
+### Receiving data from the caller
+
+Most lints work purely from the `ast`, `context`, and `ast_context`. Occasionally a program that embeds `selene-lib` as a library needs to hand a lint some structured, per-check information that isn't part of the source being linted — for example, metadata about the file that only the caller knows.
+
+For this, a caller runs the checker with `Checker::test_on_with` instead of `test_on`, attaching an arbitrary `'static` value:
+
+```rs
+let diagnostics = checker.test_on_with(&ast, Box::new(MyData { /* ... */ }));
+```
+
+Inside `pass`, the lint retrieves it by type from the `ast_context`:
+
+```rs
+fn pass(&self, ast: &Ast, _: &Context, ast_context: &AstContext) -> Vec<Diagnostic> {
+    if let Some(data) = ast_context.caller_data::<MyData>() {
+        // use the caller-provided data
+    }
+    // ...
+}
+```
+
+`caller_data::<T>()` returns `None` when the checker was run with the plain `test_on`, or when the value supplied was not of type `T`, so a lint that reads it should handle the absent case. The value is opaque to `selene-lib` — only the caller and the lint need to agree on its type.
+
 ### Getting selene to recognize the new lint
 
 Now that we have our lint, we have to make sure selene actually knows to use it. There are two places you need to update.

--- a/selene-lib/src/lib.rs
+++ b/selene-lib/src/lib.rs
@@ -225,9 +225,24 @@ macro_rules! use_lints {
             }
 
             pub fn test_on(&self, ast: &Ast) -> Vec<CheckerDiagnostic> {
-                let mut diagnostics = Vec::new();
+                self.run_lints(ast, &AstContext::from_ast(ast))
+            }
 
-                let ast_context = AstContext::from_ast(ast);
+            /// Like [`Self::test_on`], but threads opaque, caller-provided
+            /// per-check data through to the lints. Each lint retrieves it (by
+            /// type) via `ast_context.caller_data::<T>()`. This lets an embedder
+            /// hand structured per-file context to a lint without encoding it in
+            /// the source or AST.
+            pub fn test_on_with(
+                &self,
+                ast: &Ast,
+                caller_data: Box<dyn std::any::Any>,
+            ) -> Vec<CheckerDiagnostic> {
+                self.run_lints(ast, &AstContext::from_ast_with_data(ast, caller_data))
+            }
+
+            fn run_lints(&self, ast: &Ast, ast_context: &AstContext) -> Vec<CheckerDiagnostic> {
+                let mut diagnostics = Vec::new();
 
                 macro_rules! check_lint {
                     ($name:ident) => {
@@ -235,7 +250,7 @@ macro_rules! use_lints {
 
                         let lint_pass = {
                             profiling::scope!(&format!("lint: {}", stringify!($name)));
-                            lint.pass(ast, &self.context, &ast_context)
+                            lint.pass(ast, &self.context, ast_context)
                         };
 
                         diagnostics.extend(&mut lint_pass.into_iter().map(|diagnostic| {

--- a/selene-lib/src/lints.rs
+++ b/selene-lib/src/lints.rs
@@ -1,4 +1,5 @@
 use crate::{ast_util::scopes::ScopeManager, standard_library::StandardLibrary};
+use std::any::Any;
 use std::convert::TryInto;
 
 use codespan_reporting::diagnostic::{
@@ -235,15 +236,72 @@ impl Context {
     }
 }
 
-#[derive(Debug)]
 pub struct AstContext {
     pub scope_manager: ScopeManager,
+
+    // Optional opaque, caller-provided per-check data. A library caller can
+    // attach an arbitrary `'static` value via `Checker::test_on_with`, and a
+    // lint reads it back (by type) with `caller_data::<T>()`. This lets an
+    // embedder hand structured per-file context to a lint without smuggling it
+    // through the source/AST. `None` on the plain `test_on` path.
+    caller_data: Option<Box<dyn Any>>,
+}
+
+impl std::fmt::Debug for AstContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AstContext")
+            .field("scope_manager", &self.scope_manager)
+            .field(
+                "caller_data",
+                &self.caller_data.as_ref().map(|_| "<opaque>"),
+            )
+            .finish()
+    }
 }
 
 impl AstContext {
     pub fn from_ast(ast: &Ast) -> Self {
         Self {
             scope_manager: ScopeManager::new(ast),
+            caller_data: None,
         }
+    }
+
+    /// Build an `AstContext` carrying opaque, caller-provided per-check data.
+    /// Lints retrieve it (by type) with [`AstContext::caller_data`].
+    pub fn from_ast_with_data(ast: &Ast, caller_data: Box<dyn Any>) -> Self {
+        Self {
+            scope_manager: ScopeManager::new(ast),
+            caller_data: Some(caller_data),
+        }
+    }
+
+    /// Downcast the caller-provided opaque data to `T`, returning `None` when no
+    /// data was supplied or it was not of type `T`.
+    pub fn caller_data<T: Any>(&self) -> Option<&T> {
+        self.caller_data
+            .as_ref()
+            .and_then(|data| data.downcast_ref::<T>())
+    }
+}
+
+#[cfg(test)]
+mod caller_data_tests {
+    use super::AstContext;
+
+    #[test]
+    fn caller_data_roundtrips_and_is_type_checked() {
+        let ast = full_moon::parse("local x = 1").unwrap();
+
+        // Plain context carries no caller data.
+        let ctx = AstContext::from_ast(&ast);
+        assert!(ctx.caller_data::<i32>().is_none());
+
+        // Data provided by the caller is retrievable by its type.
+        let ctx = AstContext::from_ast_with_data(&ast, Box::new(42_i32));
+        assert_eq!(ctx.caller_data::<i32>(), Some(&42));
+
+        // A mismatched type yields None rather than a wrong value.
+        assert!(ctx.caller_data::<String>().is_none());
     }
 }


### PR DESCRIPTION
Closes #683.

## What
Adds a way for a program that embeds `selene-lib` to pass arbitrary, structured, per-check data to a lint without encoding it in the source being linted.

- `AstContext` gains an optional opaque (`Box<dyn Any>`) value plus a typed accessor `caller_data::<T>()`.
- `Checker::test_on_with(&ast, Box<dyn Any>)` runs the checker with that value attached; `test_on` is unchanged and equivalent to supplying no caller data.

```rust
let diagnostics = checker.test_on_with(&ast, Box::new(MyData { /* ... */ }));

// in a lint's pass():
if let Some(data) = ast_context.caller_data::<MyData>() {
    // use the caller-provided data
}
```

## Why
Lints receive `ast`, a `Context` (per-checker, e.g. the standard library) and an `AstContext` (per-file, e.g. scopes), but there is no channel for the *caller* to hand a lint its own per-file information (metadata the embedding program knows that isn't in the source). This adds a typed, opaque one.

## How
- The value is type-erased via `Any` and stored on `AstContext`; only the caller and the lint agree on its concrete type. `caller_data::<T>()` returns `None` when no data was supplied or the type does not match.
- `test_on` and `test_on_with` share a private `run_lints` helper, so lint execution is identical either way.
- No change to the `Lint::pass` signature, so existing lints are unaffected.

## Tests and docs
- Unit test covering the absent, present, and mismatched-type cases.
- New "Receiving data from the caller" section in `docs/src/contributing.md`; CHANGELOG updated.
- `cargo test`, `cargo fmt --check`, and `cargo clippy` pass; existing behavior is unchanged.
